### PR TITLE
Fix array variable name and final instance field omission

### DIFF
--- a/doc/CHANGES.txt
+++ b/doc/CHANGES.txt
@@ -1,16 +1,18 @@
-Version 2.0.1, to be released
+Version 2.0.1, released November 30, 2015
+
+Fixed a bug in the variable names for generated array declarations.
 
 Randoop now generates tests involving fields (fixes issues #21 and #47).
 A Randoop-generated test previously only invoked methods; now the
 generated tests may access and set fields as well.  Use command-line
 option --omit-field-list to make Randoop ignore certain fields.
- 
+
 Randoop now includes enums in generated tests (fixes issue #17).
 
 JUnit now executes Randoop-generated tests in a deterministic order:
 in ascending order by name.
 
-The Randoop Eclipse plugin has moved into its own repository: 
+The Randoop Eclipse plugin has moved into its own repository:
 https://github.com/randoop/randoop-eclipse-plugin
 
 

--- a/doc/index.html
+++ b/doc/index.html
@@ -14,7 +14,7 @@
 <h1>Randoop Manual</h1> <!-- omit from toc -->
 
 <p>
-This is the manual for Randoop version 1.3.6, released August 10, 2015.
+This is the manual for Randoop version 2.0.1, released November 30, 2015.
 The Randoop homepage is
 <a href="http://randoop.github.io/randoop/">http://randoop.github.io/randoop/</a>.
 </p>
@@ -252,7 +252,7 @@ and use the <tt>--classlist</tt> option: </p>
 Created file: my/home/directory/RandoopTest.java
 done.</pre>
 <p>
-The main test suite is in class <tt>RandoopTest</tt>. Compile and run the tests using a classpath including the code under test, the generated tests, and JUnit files <tt>junit.jar</tt> and <tt>hamcrest-core.jar</tt>. In this example, you should also add the current directory (&quot;.&quot;) when you run the tests. 
+The main test suite is in class <tt>RandoopTest</tt>. Compile and run the tests using a classpath including the code under test, the generated tests, and JUnit files <tt>junit.jar</tt> and <tt>hamcrest-core.jar</tt>. In this example, you should also add the current directory (&quot;.&quot;) when you run the tests.
 </p>
 
 <pre class="code">javac -classpath .:$JUNITPATH RandoopTest*.java
@@ -498,35 +498,35 @@ Randoop about your application, and that is how we recommend using Randoop.
     <ul>
       <li id="option:testclass"><b>--testclass=</b><i>string</i> <tt>[+]</tt>. Each element is the fully-qualified name of a class under test.</li>
       <li id="option:classlist"><b>--classlist=</b><i>string</i>. The name of a file that lists classes under test.
- 
+
  In the file, each class under test is specified by its
  fully-qualified name on a separate line.</li>
       <li id="option:methodlist"><b>--methodlist=</b><i>string</i>. The name of a file that lists methods under test.
- 
+
  In the file, each each method under test is specified on a separate
  line. The list of methods given by this argument augment
  any methods derived via the <tt>--testclass</tt> or
  <tt>--classlist</tt> option.
- 
- Also see the manual section on <a href="https://rawgit.com/randoop/randoop/master/doc/index.html#specifying-methods">specifying methods 
+
+ Also see the manual section on <a href="https://rawgit.com/randoop/randoop/master/doc/index.html#specifying-methods">specifying methods
  and constructors that may appear in a test</a>.</li>
       <li id="option:omitmethods"><b>--omitmethods=</b><i>regex</i>. Randoop will not attempt to directly call methods whose <code>java.lang.reflect.Method#toString()</code> matches the regular expression
  given.  This does not prevent indirect calls to such methods from
  other, allowed methods.
  <p>
- 
+
  Randoop only calls methods
  that are specified by one of the <tt>--testclass</tt>,
  <tt>-classlist</tt>, or <tt>--methodlist</tt> command-line options;
  the purpose of <tt>--omitmethods</tt> is to override one of those other
  command-line options.</li>
- 
+
  	  <li id="option:omit-field-list"><b>--omit-field-list=</b><i>string</i>. A file containing the names of fields to exclude from generated tests. Fields should be fully qualified by package and class name (e.g., <tt>java.util.Collections.EMPTY_SET</tt>))</li>
       <li id="option:init-routine"><b>--init-routine=</b><i>string</i>. Specifies initialization routine (class.method)</li>
       <li id="option:silently-ignore-bad-class-names"><b>--silently-ignore-bad-class-names=</b><i>boolean</i>. Ignore class names specified by user that cannot be found [default false]</li>
       <li id="option:literals-level"><b>--literals-level=</b><i>enum</i>. How to use literal values (see --literals-file). See: <code>ClassLiteralsMode</code>. [default CLASS]<ul><li><b>NONE</b> do not use literals specified in a literals file</li><li><b>CLASS</b> a literal for a given class is used as input only to methods of that class</li><li><b>PACKAGE</b> a literal is used as input to methods of any classes in the same package</li><li><b>ALL</b> each literal is used as input to any method under test</li></ul></li>
       <li id="option:literals-file"><b>--literals-file=</b><i>string</i> <tt>[+]</tt>. A file containing literal values to be used as inputs to methods under test.
- 
+
  Literals in these files are used in addition to all other constants in the pool.
  For the format of this file, see documentation in class <code>randoop.LiteralFileReader</code>.
  The special value "CLASSES" (with no quotes) means to read literals from all classes under test.</li>
@@ -540,7 +540,7 @@ Randoop about your application, and that is how we recommend using Randoop.
   <li id="optiongroup:Limiting-test-generation">Limiting test generation
     <ul>
       <li id="option:timelimit"><b>--timelimit=</b><i>int</i>. Maximum number of seconds to spend generating tests.
- 
+
  Used to determine when to stop test generation. Generation stops when
  either the time limit (--timelimit=int) OR the input limit
  (--inputlimit=int) is reached.
@@ -548,7 +548,7 @@ Randoop about your application, and that is how we recommend using Randoop.
  Note that if you use this option, Randoop is nondeterministic: it
  may generate different test suites on different runs. [default 100]</li>
       <li id="option:inputlimit"><b>--inputlimit=</b><i>int</i>. Maximum number of tests generated.
- 
+
  Used to determine when to stop test generation. Generation stops when
  either the time limit (--timelimit=int) OR the input limit
  (--inputlimit=int) is reached.  The number of tests output
@@ -558,10 +558,10 @@ Randoop about your application, and that is how we recommend using Randoop.
  are generated.  Contrast to --inputlimit. [default 100000000]</li>
       <li id="option:maxsize"><b>--maxsize=</b><i>int</i>. Do not generate tests with more than this many statements [default 100]</li>
       <li id="option:forbid-null"><b>--forbid-null=</b><i>boolean</i>. Never use null as input to methods or constructors.
- 
+
  This option causes Randoop to abandon the method call rather than providing
  null as an input, when no non-null value of the appropriate type is available.
- 
+
  To ask Randoop to calls methods with null with greater frequency,
  see option --null-ratio. [default true]</li>
     </ul>
@@ -572,17 +572,17 @@ Randoop about your application, and that is how we recommend using Randoop.
  65KB (or about 10,000 characters) may be rejected by the Java
  compiler, according to the Java Virtual Machine specification. [default 10000]</li>
       <li id="option:null-ratio"><b>--null-ratio=</b><i>double</i>. Use null with the given frequency.
- 
+
  If a null ratio is given, it should be between 0 and 1. A ratio of X means that
  null will be used instead of a non-null value as a parameter to method calls,
  with X frequency (1 means always use null, 0 means never use null). For example,
  a ratio of 0.5 directs Randoop to use null inputs 50 percent of the time.
- 
+
  Randoop never uses null for receiver values. [default 0.0]</li>
       <li id="option:alias-ratio"><b>--alias-ratio=</b><i>double</i>. Try to reuse values from a sequence with the given frequency.
- 
+
  If an alias ratio is given, it should be between 0 and 1.
- 
+
  A ratio of 0 results in tests where each value created within a test input is typically used at most once
  as an argument in a method call. A ratio of 1 tries to maximize the number of times
  values are used as inputs to parameters within a test. [default 0.0]</li>
@@ -605,7 +605,7 @@ Randoop about your application, and that is how we recommend using Randoop.
       <li id="option:observers"><b>--observers=</b><i>filename</i>. Use the methods specified in the given file to create regression assertions.</li>
       <li id="option:check-object-contracts"><b>--check-object-contracts=</b><i>boolean</i>. Use Randoop's default set of object contracts as assertions.
  If disabled, these assertions are not created.
- 
+
  <p>
  The default set of contracts includes:
    equals(Object) is reflexive,
@@ -629,7 +629,7 @@ Randoop about your application, and that is how we recommend using Randoop.
       <li id="option:junit-output-dir"><b>--junit-output-dir=</b><i>string</i>. Name of the directory to which JUnit files should be written</li>
       <li id="option:dont-output-tests"><b>--dont-output-tests=</b><i>boolean</i>. Run Randoop but do not create JUnit tests [default false]</li>
       <li id="option:output-nonexec"><b>--output-nonexec=</b><i>boolean</i>. Output sequences even if they do not complete execution.
- 
+
   Randoop's default behavior is to output only tests consisting of
   method call sequences that execute every statement, rather than throwing
   an exception or failing a contract check before the last statement. [default false]</li>
@@ -659,17 +659,17 @@ Randoop about your application, and that is how we recommend using Randoop.
       <li id="option:componentfile-ser"><b>--componentfile-ser=</b><i>string</i> <tt>[+]</tt>. Read serialized test inputs from the given file</li>
       <li id="option:componentfile-txt"><b>--componentfile-txt=</b><i>string</i> <tt>[+]</tt>. Read serialized test inputs from the given file (text-based)</li>
       <li id="option:output-components"><b>--output-components=</b><i>string</i>. Output components (serialized, GZIPPED) to the given file.
- 
+
  Suggestion: use a .gz suffix in file name.</li>
       <li id="option:output-tests-serialized"><b>--output-tests-serialized=</b><i>string</i>. Output tests (sequences plus checkers) in serialized form to the given file.
- 
+
  Suggestion: use a .gz suffix in file name.</li>
     </ul>
   </li>
   <li id="optiongroup:Notifications">Notifications
     <ul>
       <li id="option:comm-port"><b>--comm-port=</b><i>int</i>. Randoop uses the specified port for output, in serialized form (used by Eclipse plugin).
- 
+
  If this value is not -1, Randoop relays information about the
  program's execution over a connection to the specified port on the
  local machine. Information is sent using a serialized
@@ -1019,7 +1019,7 @@ java -ea -classpath randoop.jar randoop.main.Main help --unpub gentests
   it easier for them to diagnose the problem, fix Randoop, and verify the
   fix.  This generally includes
   <ul>
-    <li>the version of Randoop (please use the most recent released version or the current version from the version control repository),</li> 
+    <li>the version of Randoop (please use the most recent released version or the current version from the version control repository),</li>
     <li>the exact commands you ran (we recommend using the <tt>-ea</tt> option to java when running Randoop, which makes diagnosis easier),</li>
     <li>the exact and complete output of the commands, and</li>
     <li>all the files that are necessary to run those commands.</li>

--- a/src/randoop/operation/ArrayCreation.java
+++ b/src/randoop/operation/ArrayCreation.java
@@ -37,7 +37,7 @@ public final class ArrayCreation implements Operation, Serializable {
   // are computed upon the first invocation of the respective
   // getter method.
   private List<Class<?>> inputTypesCached;
-  private Class<?> outputTypeCached;
+  private Class<?> outputType;
   private int hashCodeCached;
   private boolean hashCodeComputed= false;
 
@@ -54,6 +54,7 @@ public final class ArrayCreation implements Operation, Serializable {
     // Set state variables.
     this.elementType = elementType;
     this.length = length;
+    this.outputType = Array.newInstance(elementType, 0).getClass();
   }
 
   private Object writeReplace() throws ObjectStreamException {
@@ -124,10 +125,7 @@ public final class ArrayCreation implements Operation, Serializable {
    * namely the receiver that is generated.
    */
   public Class<?> getOutputType() {
-    if (outputTypeCached == null) {
-      outputTypeCached = Array.newInstance(elementType, 0).getClass();
-    }
-    return outputTypeCached;
+    return outputType;
   }
 
   /**
@@ -138,7 +136,7 @@ public final class ArrayCreation implements Operation, Serializable {
       throw new IllegalArgumentException("Too many arguments:"
           + inputVars.size() + " capacity:" + length);
     String declaringClass = this.elementType.getCanonicalName();
-    String var = Variable.classToVariableName(this.elementType) + newVar.index;
+    String var = Variable.classToVariableName(outputType) + newVar.index;
 
     b.append(declaringClass + "[] "
              + var

--- a/src/randoop/operation/ArrayCreation.java
+++ b/src/randoop/operation/ArrayCreation.java
@@ -24,7 +24,7 @@ import randoop.util.Reflection;
  */
 public final class ArrayCreation implements Operation, Serializable {
 
-  private static final long serialVersionUID = 20100429; 
+  private static final long serialVersionUID = 20100429;
 
   /** ID for parsing purposes (see StatementKinds.parse method) */
   public static final String ID = "array";
@@ -37,7 +37,7 @@ public final class ArrayCreation implements Operation, Serializable {
   // are computed upon the first invocation of the respective
   // getter method.
   private List<Class<?>> inputTypesCached;
-  private Class<?> outputTypeCached;    
+  private Class<?> outputTypeCached;
   private int hashCodeCached;
   private boolean hashCodeComputed= false;
 
@@ -66,7 +66,7 @@ public final class ArrayCreation implements Operation, Serializable {
   public Class<?> getElementType() {
     return this.elementType;
   }
-  
+
   /**
    * Returns the length of elements held in this ArrayDeclarationInfo
    * */
@@ -90,7 +90,7 @@ public final class ArrayCreation implements Operation, Serializable {
 
   /**
    * Executes this statement, given the inputs to the statement. Returns
-   * the results of execution as an ResultOrException object and can 
+   * the results of execution as an ResultOrException object and can
    * output results to specified PrintStream.
    */
   public ExecutionOutcome execute(Object[] statementInput, PrintStream out) {
@@ -138,18 +138,18 @@ public final class ArrayCreation implements Operation, Serializable {
       throw new IllegalArgumentException("Too many arguments:"
           + inputVars.size() + " capacity:" + length);
     String declaringClass = this.elementType.getCanonicalName();
-    String var = Variable.classToVariableName(this.elementType) + "_array" + newVar.index;
-      
+    String var = Variable.classToVariableName(this.elementType) + newVar.index;
+
     b.append(declaringClass + "[] "
              + var
              + " = new " + declaringClass + "[] { ");
     for (int i = 0; i < inputVars.size(); i++) {
       if (i > 0)
         b.append(", ");
-      
+
       // In the short output format, statements like "int x = 3" are not added to a sequence; instead,
       // the value (e.g. "3") is inserted directly added as arguments to method calls.
-      Operation statementCreatingVar = inputVars.get(i).getDeclaringStatement(); 
+      Operation statementCreatingVar = inputVars.get(i).getDeclaringStatement();
       if (!GenInputsAbstract.long_format
           && ExecutableSequence.canUseShortFormat(statementCreatingVar)) {
         b.append(PrimitiveTypes.toCodeString(((NonreceiverTerm) statementCreatingVar).getValue()));
@@ -191,15 +191,15 @@ public final class ArrayCreation implements Operation, Serializable {
 
   /**
    * A string representing this array declaration. The string is of the form:
-   * 
+   *
    * TYPE[NUMELEMS]
-   * 
+   *
    * Where TYPE is the type of the array, and NUMELEMS is the number of elements.
-   * 
+   *
    * Example:
-   * 
+   *
    * int[3]
-   * 
+   *
    */
   public static Operation parse(String str) {
     int openBr = str.indexOf('[');

--- a/src/randoop/operation/FinalInstanceField.java
+++ b/src/randoop/operation/FinalInstanceField.java
@@ -1,0 +1,34 @@
+package randoop.operation;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+import randoop.sequence.Variable;
+
+public class FinalInstanceField extends PublicField {
+
+  private static final long serialVersionUID = 6214863094040724681L;
+
+  public FinalInstanceField(Field field) {
+    super(field);
+  }
+
+  @Override
+  public List<Class<?>> getSetTypes() {
+    return new ArrayList<>();
+  }
+
+  @Override
+  public List<Class<?>> getAccessTypes() {
+    List<Class<?>> types = new ArrayList<>();
+    types.add(getDeclaringClass());
+    return types;
+  }
+
+  @Override
+  public String toCode(List<Variable> inputVars) {
+    return inputVars.get(0) + "." + getName();
+  }
+
+}

--- a/src/randoop/operation/PublicField.java
+++ b/src/randoop/operation/PublicField.java
@@ -9,7 +9,7 @@ import randoop.BugInRandoopException;
 import randoop.sequence.Variable;
 
 /**
- * PublicField is an abstract class representing a public field of a class object, 
+ * PublicField is an abstract class representing a public field of a class object,
  * which can be an instance field, a static field, or a static final field.
  * Each is implemented as a separate class.
  * Meant to be adapted by either {@link FieldSetter} or {@link FieldGetter} for use as
@@ -18,58 +18,58 @@ import randoop.sequence.Variable;
  * @see InstanceField
  * @see StaticField
  * @see StaticFinalField
- * 
+ *
  * @author bjkeller
  *
  */
 public abstract class PublicField implements Serializable {
 
   private static final long serialVersionUID = -8083487154339374578L;
-  
+
   private Field field;
 
   /**
    * PublicField sets the {@link Field} object for the public field.
-   * 
+   *
    * @param field
    */
   public PublicField(Field field) {
     this.field = field;
   }
-  
+
   /**
    * getSetTypes returns a list of types needed to set a field.
    * What is returned depends on the implementing class.
-   * 
+   *
    * @return list of types needed to set the field.
    */
   public abstract List<Class<?>> getSetTypes();
-  
+
   /**
    * getAccessTypes returns a list of types needed to access the field.
-   * 
+   *
    * @return a singleton list with declaring class, or an empty list
    */
   public abstract List<Class<?>> getAccessTypes();
-  
+
   /**
    * getDeclaringClass returns the class in which the field is a member.
-   * 
+   *
    * @return class where field is declared.
    */
   public Class<?> getDeclaringClass() {
     return field.getDeclaringClass();
   }
-  
+
   /**
    * getType returns the type of the values held by the field.
-   * 
+   *
    * @return object representing type of field.
    */
   public Class<?> getType() {
     return field.getType();
   }
-  
+
   /**
    * getName returns the declared name of the field.
    * @return unqualified name of the field.
@@ -81,17 +81,17 @@ public abstract class PublicField implements Serializable {
   /**
    * toCode translates field into a string representing fully qualified
    * name.
-   * 
+   *
    * @param inputVars - list of input variables
    * @return string representing code representation of field.
    */
   public abstract String toCode(List<Variable> inputVars);
-  
+
   /**
    * toParseableString returns a string descriptor of a field that can be parsed by
    * {@link PublicFieldParser#parse(String)}.
-   * 
-   * @return String for type-field pair describing field. 
+   *
+   * @return String for type-field pair describing field.
    */
   public String toParseableString() {
     return field.getType().getName() + ":" + field.getDeclaringClass().getName() + "." + field.getName();
@@ -101,7 +101,7 @@ public abstract class PublicField implements Serializable {
   public String toString() {
     return toParseableString();
   }
-  
+
   @Override
   public boolean equals(Object obj) {
     if (obj instanceof PublicField) {
@@ -110,7 +110,7 @@ public abstract class PublicField implements Serializable {
     }
     return false;
   }
-  
+
   @Override
   public int hashCode() {
     return field.hashCode();
@@ -119,7 +119,7 @@ public abstract class PublicField implements Serializable {
   /**
    * getValue uses reflection to return the value of the field for the given object.
    * Suppresses exceptions that occur because PublicField was not correctly initialized.
-   * 
+   *
    * @param object - instance to which field belongs, or null if field is static.
    * @return reference to value of field.
    * @throws BugInRandoopException if field access throws {@link IllegalArgumentException} or {@link IllegalAccessException}.
@@ -139,7 +139,7 @@ public abstract class PublicField implements Serializable {
   /**
    * setValue uses reflection to set the value of the field for the given object.
    * Suppresses exceptions that occur because setup was incorrect.
-   * 
+   *
    * @param object - instance to which field belongs, or null if static.
    * @param value - new value to assign to field
    * @throws BugInRandoopException if field access throws {@link IllegalArgumentException} or {@link IllegalAccessException}.
@@ -148,20 +148,20 @@ public abstract class PublicField implements Serializable {
     try {
       field.set(object, value);
     } catch (IllegalArgumentException e) {
-      throw new BugInRandoopException("Field set to object of wrong type" + e.getMessage());
+      throw new BugInRandoopException("Field set to object of wrong type: " + e.getMessage());
     } catch (IllegalAccessException e) {
-      throw new BugInRandoopException("Access control violation for field" + e.getMessage());
+      throw new BugInRandoopException("Access control violation for field: " + e.getMessage());
     }
   }
 
   /**
    * writeReplace creates {@link Serializable} version of field.
-   * 
+   *
    * @return representation of field.
    * @see SerializablePublicField
    */
   protected Object writeReplace() throws ObjectStreamException {
     return new SerializablePublicField(field);
   }
-  
+
 }

--- a/src/randoop/operation/PublicFieldParser.java
+++ b/src/randoop/operation/PublicFieldParser.java
@@ -13,7 +13,7 @@ import randoop.util.Reflection;
  * The parser first checks that the descriptor is in the right syntactic form, then extracts
  * the type and field-name and uses reflection to determine if the field belongs to the class,
  * and the types match.
- * 
+ *
  * @author bjkeller
  *
  */
@@ -23,7 +23,7 @@ public class PublicFieldParser {
    * parse recognizes a type-field pair in a string, and
    * returns the relevant object based on properties of the field
    * determined by reflection.
-   * 
+   *
    * @param s - a string in the form of "<type>:<field-name>"
    * @return a reference to a PublicField object represented by the pair in the string.
    * @throws OperationParseException
@@ -111,9 +111,9 @@ public class PublicFieldParser {
 
   /**
    * recognize determines what sort of field is given.
-   * Looking for a field to be an instance field, 
+   * Looking for a field to be an instance field,
    * a static field, or a static final field.
-   * 
+   *
    * @param field
    * @return an object of a subclass of PublicField.
    */
@@ -127,7 +127,11 @@ public class PublicFieldParser {
         pf = new StaticField(field);
       }
     } else {
-      pf = new InstanceField(field);
+      if (Modifier.isFinal(mods)) {
+        pf = new FinalInstanceField(field);
+      } else {
+        pf = new InstanceField(field);
+      }
     }
     assert pf != null;
     return pf;
@@ -135,7 +139,7 @@ public class PublicFieldParser {
 
   /**
    * fieldFor searches the field list of a class for a field that has the given name.
-   * 
+   *
    * @param type - class object.
    * @param fieldName - field name for which to search the class.
    * @return field of the class with the given name.

--- a/src/randoop/sequence/VariableRenamer.java
+++ b/src/randoop/sequence/VariableRenamer.java
@@ -76,10 +76,12 @@ public class VariableRenamer {
     }
     // renaming for array type
     if (clz.isArray()) {
+      String arraySuffix = "";
       while (clz.isArray()) {
+        arraySuffix += "_array";
         clz = clz.getComponentType();
       }
-      return getVariableName(clz) + "_array";
+      return getVariableName(clz) + arraySuffix;
     }
     //for object, string, class types
     if (clz.equals(Object.class)) {

--- a/tests/randoop/operation/ArrayCreationTests.java
+++ b/tests/randoop/operation/ArrayCreationTests.java
@@ -14,7 +14,7 @@ public class ArrayCreationTests extends TestCase{
   public void test1() throws Exception {
     ArrayCreation ad= new ArrayCreation(String.class, 1);
     StringBuilder b= new StringBuilder();
-    Sequence seq = new Sequence().extend(new NonreceiverTerm(String.class, "mystring")); 
+    Sequence seq = new Sequence().extend(new NonreceiverTerm(String.class, "mystring"));
     Variable var0 = new Variable(seq, 0);
     Variable var1 = new Variable(seq, 1);
     ArrayList<Variable> input = new ArrayList<Variable>();
@@ -26,7 +26,7 @@ public class ArrayCreationTests extends TestCase{
   public void test2() throws Exception {
     ArrayCreation ad= new ArrayCreation(char.class, 1);
     StringBuilder b= new StringBuilder();
-    Sequence seq = new Sequence().extend(new NonreceiverTerm(char.class, 'c')); 
+    Sequence seq = new Sequence().extend(new NonreceiverTerm(char.class, 'c'));
     Variable var0 = new Variable(seq, 0);
     Variable var1 = new Variable(seq, 1);
     ArrayList<Variable> input = new ArrayList<Variable>();
@@ -38,13 +38,13 @@ public class ArrayCreationTests extends TestCase{
   public void test3() throws Exception {
     ArrayCreation ad= new ArrayCreation(char[].class, 1);
     StringBuilder b= new StringBuilder();
-    Sequence seq = new Sequence().extend(new ArrayCreation(char[].class, 0)); 
+    Sequence seq = new Sequence().extend(new ArrayCreation(char[].class, 0));
     Variable var0 = new Variable(seq, 0);
     Variable var1 = new Variable(seq, 1);
     ArrayList<Variable> input = new ArrayList<Variable>();
     input.add(var0);
     ad.appendCode(var1, input, b);
-    assertEquals("char[][] char_array_array1 = new char[][] { char_array0};" + Globals.lineSep + "", b.toString());
+    assertEquals("char[][] char_array_array1 = new char[][] { char_array_array0};" + Globals.lineSep + "", b.toString());
   }
 
 }


### PR DESCRIPTION
This fixes two things:
1) the mismatch between variable names for arrays where declared variable had additional "_array".
2) the omission of final instance variables from the PublicField hierarchy. Final instance variables were being treated as mutable.

user doc and version numbers updated to v.2.0.1