### PR TITLE
A nicer shade of flaky

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -596,24 +596,24 @@ Randoop about your application, and that is how we recommend using Randoop.
   <li id="optiongroup:Code-under-test">Code under test
     <ul>
       <li id="option:testclass"><b>--testclass=</b><i>string</i> <tt>[+]</tt>. The fully-qualified name of a class to test.
- This class is tested in addition to any specified using
- <tt>--classlist</tt>, and must be accessible from the package of the tests
+ This class is tested in addition to any specified using 
+ <tt>--classlist</tt>, and must be accessible from the package of the tests 
  (set with <tt>--junit-package-name</tt>).</li>
       <li id="option:classlist"><b>--classlist=</b><i>string</i>. The name of a file that lists classes to test.
-
+ 
  In the file, each class under test is specified by its
  fully-qualified name on a separate line.
  See an <a href="https://raw.githubusercontent.com/randoop/randoop/master/doc/class_list_example.txt">example</a>.
  These classes are tested in addition to any specified using <tt>--testclass</tt>.
- All classes must be accessible from the package of the tests
+ All classes must be accessible from the package of the tests 
  (set with <tt>--junit-package-name</tt>).</li>
       <li id="option:methodlist"><b>--methodlist=</b><i>string</i>. The name of a file that lists methods to test.
-
+ 
  In the file, each each method under test is specified on a separate
  line. The list of methods given by this argument augment
  any methods derived via the <tt>--testclass</tt> or
  <tt>--classlist</tt> option.
-
+ 
  <p>
  A constructor line begins with <code>"cons :"</code> followed by the
  classname, the string <code>&lt;init&gt;</code> and the constructor's
@@ -633,7 +633,7 @@ Randoop about your application, and that is how we recommend using Randoop.
  given.  This does not prevent indirect calls to such methods from
  other, allowed methods.
  <p>
-
+ 
  Randoop only calls methods
  that are specified by one of the <tt>--testclass</tt>,
  <tt>-classlist</tt>, or <tt>--methodlist</tt> command-line options;
@@ -643,7 +643,7 @@ Randoop about your application, and that is how we recommend using Randoop.
  field names to be excluded from test generation. Otherwise, Randoop
  includes all public fields of a visible class.</li>
       <li id="option:only-test-public-members"><b>--only-test-public-members=</b><i>boolean</i>. Restrict tests to only include public members of classes.
- Ordinarily, the setting of <tt>--junit-package-name</tt> and package
+ Ordinarily, the setting of <tt>--junit-package-name</tt> and package 
  accessibility is used to determine which members will be used in tests.
  Using this option restricts the tests to only use public members even if
  the class is a member of the same package as the generated tests. [default false]</li>
@@ -654,13 +654,13 @@ Randoop about your application, and that is how we recommend using Randoop.
     <ul>
       <li id="option:no-error-revealing-tests"><b>--no-error-revealing-tests=</b><i>boolean</i>. Whether to output error-revealing tests.
  <p>
- Will completely disable output when used with
+ Will completely disable output when used with 
  <code>--no-regression-tests</code>.
  Be aware that restricting output can result in long runs if the default
  values of <code>--inputlimit</code> and <code>--timelimit</code> are used. [default false]</li>
       <li id="option:no-regression-tests"><b>--no-regression-tests=</b><i>boolean</i>. Whether to output regression tests.
  <p>
- Will completely disable output when used with
+ Will completely disable output when used with 
  <code>--no-error-revealing-tests</code>.
  Be aware that restricting output can result in long runs if the default
  values of <code>--inputlimit</code> and <code>--timelimit</code> are used. [default false]</li>
@@ -670,44 +670,48 @@ Randoop about your application, and that is how we recommend using Randoop.
  throw an exception of the same type).
  Tests without assertions can be used to exercise the code, but they
  do not enforce any particular behavior, such as values returned. [default false]</li>
-      <li id="option:checked-exception"><b>--checked-exception=</b><i>enum</i>. If a test throws a checked exception, should it be included in the
- error-revealing test suite (value: ERROR), regression test suite
+      <li id="option:checked-exception"><b>--checked-exception=</b><i>enum</i>. If a test throws a checked exception, should it be included in the 
+ error-revealing test suite (value: ERROR), regression test suite 
  (value: EXPECTED), or should it be discarded (value: INVALID)? [default EXPECTED]<ul><li><b>INVALID</b> Occurrence of exception should be considered invalid</li><li><b>ERROR</b> Occurrence of exception should be considered an error</li><li><b>EXPECTED</b> Occurrence of exception should be considered expected behavior</li></ul></li>
-      <li id="option:unchecked-exception"><b>--unchecked-exception=</b><i>enum</i>. If a test throws a unchecked exception, should the test be included in the
- error-revealing test suite (value: ERROR), regression test suite
- (value: EXPECTED), or should it be discarded (value: INVALID)?
+      <li id="option:unchecked-exception"><b>--unchecked-exception=</b><i>enum</i>. If a test throws a unchecked exception, should the test be included in the 
+ error-revealing test suite (value: ERROR), regression test suite 
+ (value: EXPECTED), or should it be discarded (value: INVALID)? 
  <p>
- The arguments --npe-on-null-input and --oom-exception handle special cases of
+ The arguments --npe-on-null-input and --oom-exception handle special cases of 
  unchecked exceptions. [default EXPECTED]<ul><li><b>INVALID</b> Occurrence of exception should be considered invalid</li><li><b>ERROR</b> Occurrence of exception should be considered an error</li><li><b>EXPECTED</b> Occurrence of exception should be considered expected behavior</li></ul></li>
-      <li id="option:npe-on-null-input"><b>--npe-on-null-input=</b><i>enum</i>. If a test where a <code>null</code> value is given as an input throws a
- <code>NullPointerException</code>, should the test be be included in the
- error-revealing test suite (value: ERROR), regression test suite
+      <li id="option:npe-on-null-input"><b>--npe-on-null-input=</b><i>enum</i>. If a test where a <code>null</code> value is given as an input throws a 
+ <code>NullPointerException</code>, should the test be be included in the 
+ error-revealing test suite (value: ERROR), regression test suite 
  (value: EXPECTED), or should it be discarded (value: INVALID)?
  <p>
  Alternatively see <code>--npe-on-non-null-input</code> [default EXPECTED]<ul><li><b>INVALID</b> Occurrence of exception should be considered invalid</li><li><b>ERROR</b> Occurrence of exception should be considered an error</li><li><b>EXPECTED</b> Occurrence of exception should be considered expected behavior</li></ul></li>
       <li id="option:npe-on-non-null-input"><b>--npe-on-non-null-input=</b><i>enum</i>. If a test where no <code>null</code> values are given as an input throws a
- <code>NullPointerExceptoin</code>, should the test be included in the
- error-revealing test suite (value: ERROR), regression test suite
+ <code>NullPointerExceptoin</code>, should the test be included in the 
+ error-revealing test suite (value: ERROR), regression test suite 
  (value: EXPECTED), or should it be discarded (value: INVALID)?
  <p>
  Alternatively, see <code>--npe-on-null-input</code> [default ERROR]<ul><li><b>INVALID</b> Occurrence of exception should be considered invalid</li><li><b>ERROR</b> Occurrence of exception should be considered an error</li><li><b>EXPECTED</b> Occurrence of exception should be considered expected behavior</li></ul></li>
-      <li id="option:oom-exception"><b>--oom-exception=</b><i>enum</i>. If a test throws an <code>OutOfMemoryError</code> exception, should it be
- included in the error-revealing test suite (value: ERROR), regression test
+      <li id="option:oom-exception"><b>--oom-exception=</b><i>enum</i>. If a test throws an <code>OutOfMemoryError</code> exception, should it be 
+ included in the error-revealing test suite (value: ERROR), regression test 
  suite (value: EXPECTED), or should it be discarded (value: INVALID)? [default INVALID]<ul><li><b>INVALID</b> Occurrence of exception should be considered invalid</li><li><b>ERROR</b> Occurrence of exception should be considered an error</li><li><b>EXPECTED</b> Occurrence of exception should be considered expected behavior</li></ul></li>
       <li id="option:ignore-flaky-tests"><b>--ignore-flaky-tests=</b><i>boolean</i>. Ignore the situation where a code sequence that previously executed
  normally throws an exception when executed as part of a longer test
  sequence. If true, the sequence will be classified as invalid.
  If false, Randoop will halt with information about the sequence to aid with
- identifying the issue. [default false]</li>
+ identifying the issue.
+ <p>
+ Use of this option is a last resort.  Flaky tests are usually due to
+ calling Randoop on side-effecting methods, and a better solution is
+ not to call Randoop on such methods. [default false]</li>
     </ul>
   </li>
   <li id="optiongroup:Limiting-test-generation">Limiting test generation
     <ul>
       <li id="option:timelimit"><b>--timelimit=</b><i>int</i>. Maximum number of seconds to spend generating tests.
-
- Test generation stops when either the time limit (--timelimit) is reached,
- OR the number of generated sequences reaches the input limit (--inputlimit),
- OR the number of error-revealing and regression tests reaches the output
+ 
+ Test generation stops when either the time limit (--timelimit) is reached, 
+ OR the number of generated sequences reaches the input limit (--inputlimit), 
+ OR the number of error-revealing and regression tests reaches the output 
  limit (--outputlimit).
 
  The default value is appropriate for generating tests for a single
@@ -717,37 +721,37 @@ Randoop about your application, and that is how we recommend using Randoop.
  Note that if you use this option, Randoop is nondeterministic: it
  may generate different test suites on different runs. [default 100]</li>
       <li id="option:outputlimit"><b>--outputlimit=</b><i>int</i>. The maximum number of regression and error-revealing tests to output.
- Test generation stops when either the time limit (--timelimit) is reached,
- OR the number of generated sequences reaches the input limit (--inputlimit),
- OR the number of error-revealing and regression tests reaches the output
+ Test generation stops when either the time limit (--timelimit) is reached, 
+ OR the number of generated sequences reaches the input limit (--inputlimit), 
+ OR the number of error-revealing and regression tests reaches the output 
  limit (--outputlimit).
  <p>
  This option affects how many tests will occur in the output, as opposed to
- --inputlimit, which affects the number of test method candidates that are
- generated internally. This option is a better choice for controlling the
- tests you get, because the number of candidates generated will always be
- larger than the number output since redundant and invalid tests are filtered.
- However, the current implementation means that the actual number of tests
+ --inputlimit, which affects the number of test method candidates that are 
+ generated internally. This option is a better choice for controlling the 
+ tests you get, because the number of candidates generated will always be 
+ larger than the number output since redundant and invalid tests are filtered. 
+ However, the current implementation means that the actual number of tests 
  in the output can still be substantially smaller than this limit.
  <p>
  This limit will have no effect if there is no output, which occurs when
- using either <code>--dont-output-tests</code> or
- <code>--no-error-revealing-tests</code> together with
- <code>--no-regression-tests</code>.
+ using either <code>--dont-output-tests</code> or 
+ <code>--no-error-revealing-tests</code> together with 
+ <code>--no-regression-tests</code>. 
  In this case, the option <code>--inputlimit</code> should be used. [default 100000000]</li>
       <li id="option:inputlimit"><b>--inputlimit=</b><i>int</i>. Maximum number of test method candidates generated.
- Test generation stops when either the time limit (--timelimit) is reached,
- OR the number of generated sequences reaches the input limit (--inputlimit),
- OR the number of error-revealing and regression tests reaches the output
- limit (--outputlimit).
- The number of tests output will be smaller than then number of test
+ Test generation stops when either the time limit (--timelimit) is reached, 
+ OR the number of generated sequences reaches the input limit (--inputlimit), 
+ OR the number of error-revealing and regression tests reaches the output 
+ limit (--outputlimit).  
+ The number of tests output will be smaller than then number of test 
  candidates generated, because redundant and illegal tests may be discarded.
  <p>
  This limit should be used when no tests are output, which occurs when
- using either <code>--dont-output-tests</code> or
- <code>--no-error-revealing-tests</code> together with
+ using either <code>--dont-output-tests</code> or 
+ <code>--no-error-revealing-tests</code> together with 
  <code>--no-regression-tests</code>.
- Otherwise the <code>--outputlimit</code> command-line option is usually
+ Otherwise the <code>--outputlimit</code> command-line option is usually 
  more appropriate. [default 100000000]</li>
       <li id="option:maxsize"><b>--maxsize=</b><i>int</i>. Do not generate tests with more than this many statements [default 100]</li>
     </ul>
@@ -755,29 +759,29 @@ Randoop about your application, and that is how we recommend using Randoop.
   <li id="optiongroup:Values-used-in-tests">Values used in tests
     <ul>
       <li id="option:null-ratio"><b>--null-ratio=</b><i>double</i>. Use null with the given frequency as an argument to method calls.
-
+ 
  For example, a null ratio of 0.05 directs Randoop to use
  <code>null</code> as an input 5 percent of the time when a
  non-<code>null</code> value of the appropriate type is available.
-
- Unless --forbid_null is true, a <code>null</code> value will still be used
+ 
+ Unless --forbid_null is true, a <code>null</code> value will still be used 
  if no other value can be passed as an argument even if --null-ratio=0.
-
- Randoop never uses <code>null</code> for receiver values. [default 0.05]</li>
-      <li id="option:forbid-null"><b>--forbid-null=</b><i>boolean</i>. Do not use <code>null</code> as input to methods or constructors when no
+ 
+ Randoop never uses <code>null</code> for receiver values. [default 0.0]</li>
+      <li id="option:forbid-null"><b>--forbid-null=</b><i>boolean</i>. Do not use <code>null</code> as input to methods or constructors when no 
  other argument value can be generated.
  <p>
  If true, Randoop will not generate a test when unable to find a non-null
  value of appropriate type as an input. This could result in certain class
  members being untested.
  <p>
- Does not affect the behavior based on --null_ratio, which independently
- determines the frequency that <code>null</code> is used as an input. [default false]</li>
+ Does not affect the behavior based on --null_ratio, which independently 
+ determines the frequency that <code>null</code> is used as an input. [default true]</li>
       <li id="option:literals-file"><b>--literals-file=</b><i>string</i> <tt>[+]</tt>. A file containing literal values to be used as inputs to methods under test.
  <p>
- Literals in these files are used in addition to all other constants in the
- pool. For the format of this file, see documentation in class
- <code>randoop.LiteralFileReader</code>. The special value "CLASSES" (with no
+ Literals in these files are used in addition to all other constants in the 
+ pool. For the format of this file, see documentation in class 
+ <code>randoop.LiteralFileReader</code>. The special value "CLASSES" (with no 
  quotes) means to read literals from all classes under test.</li>
       <li id="option:literals-level"><b>--literals-level=</b><i>enum</i>. How to use literal values that are specified via the
  <tt>--literals-file</tt> command-line option. See: <code>ClassLiteralsMode</code>. [default CLASS]<ul><li><b>NONE</b> do not use literals specified in a literals file</li><li><b>CLASS</b> a literal for a given class is used as input only to methods of that class</li><li><b>PACKAGE</b> a literal is used as input to methods of any classes in the same package</li><li><b>ALL</b> each literal is used as input to any method under test</li></ul></li>
@@ -820,14 +824,14 @@ Randoop about your application, and that is how we recommend using Randoop.
  or class members in a test. Tests can be restricted to public members only
  by using the option <tt>--only-test-public-members</tt>. [default ]</li>
       <li id="option:junit-output-dir"><b>--junit-output-dir=</b><i>string</i>. Name of the directory to which JUnit files should be written</li>
-      <li id="option:dont-output-tests"><b>--dont-output-tests=</b><i>boolean</i>. Run test generation without output.
- May be desirable when running with a visitor.
+      <li id="option:dont-output-tests"><b>--dont-output-tests=</b><i>boolean</i>. Run test generation without output. 
+ May be desirable when running with a visitor. 
  <p>
- NOTE: Because there is no output, the value of <code>--outputlimit</code>
+ NOTE: Because there is no output, the value of <code>--outputlimit</code> 
  will never be met, so be sure to set <code>--inputlimit</code> or
  <code>--timelimit</code> to a reasonable value when using this option. [default false]</li>
-      <li id="option:include-only-classes"><b>--include-only-classes=</b><i>regex</i>. Indicate which classes that any test written to output must use.
- Written test suites will only include tests that have at least one
+      <li id="option:include-only-classes"><b>--include-only-classes=</b><i>regex</i>. Indicate which classes that any test written to output must use. 
+ Written test suites will only include tests that have at least one 
  use of a member of a class whose name matches the regular expression.</li>
       <li id="option:junit-reflection-allowed"><b>--junit-reflection-allowed=</b><i>boolean</i>. Whether to use JUnit's standard reflective mechanisms for invoking
  tests.  JUnit's reflective invocations can interfere with code

--- a/doc/index.html
+++ b/doc/index.html
@@ -751,7 +751,7 @@ Randoop about your application, and that is how we recommend using Randoop.
  Unless --forbid_null is true, a <code>null</code> value will still be used 
  if no other value can be passed as an argument even if --null-ratio=0.
  
- Randoop never uses <code>null</code> for receiver values. [default 0.05]</li>
+ Randoop never uses <code>null</code> for receiver values. [default 0.0]</li>
       <li id="option:forbid-null"><b>--forbid-null=</b><i>boolean</i>. Do not use <code>null</code> as input to methods or constructors when no 
  other argument value can be generated.
  <p>
@@ -760,7 +760,7 @@ Randoop about your application, and that is how we recommend using Randoop.
  members being untested.
  <p>
  Does not affect the behavior based on --null_ratio, which independently 
- determines the frequency that <code>null</code> is used as an input. [default false]</li>
+ determines the frequency that <code>null</code> is used as an input. [default true]</li>
       <li id="option:literals-file"><b>--literals-file=</b><i>string</i> <tt>[+]</tt>. A file containing literal values to be used as inputs to methods under test.
  <p>
  Literals in these files are used in addition to all other constants in the 

--- a/src/randoop/main/Main.java
+++ b/src/randoop/main/Main.java
@@ -91,18 +91,15 @@ public class Main {
 
     } catch (SequenceExceptionError e) {
       
-      System.out.println();
-      String msg;
-      msg = "ERROR: " + Globals.lineSep
-          + "Randoop stopped because of a flaky test" + Globals.lineSep
-          + "This is probably because you ran Randoop on methods that are" + Globals.lineSep
-          + "nondeterministic or depend on global state." + Globals.lineSep
-          + "Please see the \"Randoop stopped because of a flaky test\"" + Globals.lineSep
-          + "troubleshooting section of the user manual." + Globals.lineSep;
-      System.out.println(msg);
-      System.out.println("Exception: " + Globals.lineSep + "  " + e.getError());
-      System.out.println("Statement: " + Globals.lineSep + "  " + e.getStatement());
-      System.out.println("Full sequence:" + Globals.lineSep + e.getSequence());
+      System.out.printf("ERROR:%n" 
+          + "Randoop stopped because of a flaky test.%n"
+          + "This is probably because you ran Randoop on methods that are%n"
+          + "nondeterministic or depend on global state.%n"
+          + "Please see the \"Randoop stopped because of a flaky test\"%n"
+          + "troubleshooting section of the user manual.%n");
+      System.out.printf("Exception:%n  %s%n", e.getError());
+      System.out.printf("Statement:%n  %s%n", e.getStatement());
+      System.out.printf("Full sequence:%n%s%n", e.getSequence());
       System.exit(1);
       
     } catch (Throwable e) {

--- a/src/randoop/main/Main.java
+++ b/src/randoop/main/Main.java
@@ -96,9 +96,9 @@ public class Main {
           + "This is probably because you ran Randoop on methods that side-effect global%n"
           + "state.  Please see the \"Randoop stopped because of a flaky test\"%n"
           + "section of the user manual.%n");
-      System.out.println("Exception:%n  %s%n", e.getError());
-      System.out.println("Statement:%n  %s%n", e.getStatement());
-      System.out.println("Full sequence:%n%s%n", e.getSequence());
+      System.out.printf("Exception:%n  %s%n", e.getError());
+      System.out.printf("Statement:%n  %s%n", e.getStatement());
+      System.out.printf("Full sequence:%n%s%n", e.getSequence());
       System.exit(1);
       
     } catch (Throwable e) {

--- a/src/randoop/sequence/SequenceExceptionError.java
+++ b/src/randoop/sequence/SequenceExceptionError.java
@@ -1,28 +1,64 @@
 package randoop.sequence;
 
+/**
+ * Exception representing occurrence of a "flaky" test sequence where an
+ * exception was thrown by a statement other than the last of the sequence.
+ * 
+ */
 public class SequenceExceptionError extends Error {
 
   /** ID for serialization */
   private static final long serialVersionUID = 4778297090156993454L;
-  private Throwable e;
-  private ExecutableSequence sequence;
-  private int pos;
   
-  public SequenceExceptionError(ExecutableSequence sequence, int pos, Throwable e) {
-    super("Exception thrown before end of sequence",e);
+  /** The exception thrown by the sequence */
+  private Throwable e;
+  
+  /** The test sequence */
+  private ExecutableSequence sequence;
+  
+  /** The position of the statement that threw the exception */
+  private int position;
+  
+  /**
+   * Create an exception for the exception thrown by the statement at the given
+   * position in the test sequence.
+   * 
+   * @param sequence  the test sequence
+   * @param position  the position of the statement that threw the exception
+   * @param exception  the exception
+   */
+  public SequenceExceptionError(ExecutableSequence sequence, 
+                                int position, 
+                                Throwable exception) {
+    super("Exception thrown before end of sequence", exception);
     this.sequence = sequence;
-    this.pos = pos;
-    this.e = e;
+    this.position = position;
+    this.e = exception;
   }
   
+  /**
+   * Returns the thrown exception.
+   * 
+   * @return the exception thrown by statement in sequence
+   */
   public Throwable getError() {
     return e;
   }
 
+  /**
+   * Returns the string representation of the statement that threw the exception.
+   * 
+   * @return the string representation of the statement
+   */
   public String getStatement() {
-    return sequence.statementToCodeString(pos);
+    return sequence.statementToCodeString(position);
   }
   
+  /**
+   * Returns the string representation of the test sequence.
+   * 
+   * @return the full test sequence as a string
+   */
   public String getSequence() {
     return sequence.toCodeString();
   }

--- a/src/randoop/test/ValidityCheckingVisitor.java
+++ b/src/randoop/test/ValidityCheckingVisitor.java
@@ -10,27 +10,31 @@ import randoop.test.predicate.ExceptionPredicate;
  * A {@code ValidityCheckingVisitor} checks for occurrences of exceptions that
  * have been tagged as invalid behaviors as represented by a 
  * {@code ExceptionPredicate}.
- * Also, either ignores or reports "flaky" test sequences --- an input 
+ * Also, either ignores or reports "flaky" test sequences -- an input 
  * sequence that throws an exception in a longer test sequence, despite having
  * run normally by itself.
- * Ignored flaky sequences are classified as invalid.
+ * Ignores flaky sequences are classified as invalid.
  * Flaky occurrences of {@code OutOfMemoryError} are always treated as invalid.
  */
 public class ValidityCheckingVisitor implements TestCheckGenerator {
 
+  /** The predicate to determine whether a test sequence is valid */
   private ExceptionPredicate isInvalid;
-  private boolean reportFlaky;
+  
+  /** The flag to determine whether to report flaky tests by throwing an exception */
+  private boolean throwExceptionOnFlakyTest;
 
   /**
    * Creates an object that looks for invalid exceptions.
    * 
    * @param isInvalid  the predicate to test for invalid exceptions
-   * @param reportFlaky  a flag indicating whether to report flaky tests by
-   *                     throwing an exception
+   * @param throwExceptionOnFlakyTest  a flag indicating whether to report flaky 
+   *                                   tests by throwing an exception
    */
-  public ValidityCheckingVisitor(ExceptionPredicate isInvalid, boolean reportFlaky) {
+  public ValidityCheckingVisitor(ExceptionPredicate isInvalid, 
+                                 boolean throwExceptionOnFlakyTest) {
     this.isInvalid = isInvalid;
-    this.reportFlaky = reportFlaky;
+    this.throwExceptionOnFlakyTest = throwExceptionOnFlakyTest;
   }
 
   /**
@@ -56,7 +60,7 @@ public class ValidityCheckingVisitor implements TestCheckGenerator {
         Throwable e = exec.getException();
         
         if (i != finalIndex) {
-          if (reportFlaky && ! (e instanceof OutOfMemoryError)) {
+          if (throwExceptionOnFlakyTest && ! (e instanceof OutOfMemoryError)) {
             throw new SequenceExceptionError(s, i, e);            
           }
           checks.add(new InvalidExceptionCheck(e, i, e.getClass().getName()));


### PR DESCRIPTION
This PR:

1. always classifies a flaky OOM as an invalid test, rather than throwing an exception.
2. improves message for error output when flaky tests occur.
2. allows the user to turn off the strict intolerance for flaky tests using --ignore-flaky-tests.
3. changes defaults for forbid-null and null-ratio to false and 0.05.
