### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/src/main/java/randoop/JavaFileWriter.java
+++ b/src/main/java/randoop/JavaFileWriter.java
@@ -15,6 +15,9 @@ import randoop.util.Log;
  */
 public class JavaFileWriter {
 
+  private JavaFileWriter() {
+  }
+
   // Creates Junit tests for the faults.
   // Output is a set of .java files.
   public static void createJavaFiles(

--- a/src/main/java/randoop/contract/ObjectContractUtils.java
+++ b/src/main/java/randoop/contract/ObjectContractUtils.java
@@ -14,7 +14,10 @@ import randoop.util.Timer;
  */
 public class ObjectContractUtils {
 
-  /**
+    private ObjectContractUtils() {
+    }
+
+    /**
    * Executes the given contract via reflection.
    *
    * @param c

--- a/src/main/java/randoop/field/FieldParser.java
+++ b/src/main/java/randoop/field/FieldParser.java
@@ -10,7 +10,9 @@ import randoop.types.RandoopTypeException;
  * Created by bjkeller on 3/29/16.
  */
 public class FieldParser {
-
+  
+  private FieldParser() {
+  }
 
   public static AccessibleField parse(String descr, String classname, String fieldname) throws OperationParseException {
     String errorPrefix = "Error when parsing field " + descr + ".";

--- a/src/main/java/randoop/generation/HelperSequenceCreator.java
+++ b/src/main/java/randoop/generation/HelperSequenceCreator.java
@@ -30,7 +30,10 @@ import randoop.util.SimpleList;
 
 public class HelperSequenceCreator {
 
-  /**
+    private HelperSequenceCreator() {
+    }
+
+    /**
    * Returns a sequence that creates an object of type compatible with the given
    * class. Wraps the object in a list, and returns the list.
    *

--- a/src/main/java/randoop/main/ExceptionBehaviorClassifier.java
+++ b/src/main/java/randoop/main/ExceptionBehaviorClassifier.java
@@ -9,6 +9,9 @@ import randoop.sequence.ExecutableSequence;
  */
 public class ExceptionBehaviorClassifier {
 
+  private ExceptionBehaviorClassifier() {
+  }
+
   /**
    * Classifies a {@code Throwable} thrown by the {@code ExecutableSequence}
    * using the command-line arguments

--- a/src/main/java/randoop/operation/OperationParser.java
+++ b/src/main/java/randoop/operation/OperationParser.java
@@ -8,6 +8,9 @@ import randoop.reflection.TypedOperationManager;
 
 public class OperationParser {
 
+  private OperationParser() {
+  }
+
   /**
    * Parses a string representing a StatementKind. The string is expected to be
    * of the form:

--- a/src/main/java/randoop/reflection/LiteralFileReader.java
+++ b/src/main/java/randoop/reflection/LiteralFileReader.java
@@ -62,6 +62,9 @@ public class LiteralFileReader {
   private static final String CLASSNAME = "CLASSNAME";
   private static final String LITERALS = "LITERALS";
 
+  private LiteralFileReader() {
+  }
+
   /**
    * Returns a map from class to list of constants.
    *

--- a/src/main/java/randoop/util/JarReader.java
+++ b/src/main/java/randoop/util/JarReader.java
@@ -12,6 +12,9 @@ public class JarReader {
 
   private static boolean debug = false;
 
+  private JarReader() {
+  }
+
   public static void main(String[] args) throws IOException {
     List<String> names = getClasseNamesInJar(args[0]);
     Collections.sort(names);

--- a/src/main/java/randoop/util/ReflectionExecutor.java
+++ b/src/main/java/randoop/util/ReflectionExecutor.java
@@ -42,6 +42,9 @@ public final class ReflectionExecutor {
   private static long excep_exec_accum = 0;
   private static int excep_exec_count = 0;
 
+  private ReflectionExecutor() {
+  }
+
   public static int normalExecs() {
     return normal_exec_count;
   }

--- a/src/main/java/randoop/util/StringEscapeUtils.java
+++ b/src/main/java/randoop/util/StringEscapeUtils.java
@@ -61,7 +61,7 @@ public class StringEscapeUtils {
    * to operate.
    * </p>
    */
-  public StringEscapeUtils() { // Empty.
+  private StringEscapeUtils() { // Empty.
   }
 
   // Java and JavaScript

--- a/src/testinput/java/muse/SortContainer.java
+++ b/src/testinput/java/muse/SortContainer.java
@@ -8,15 +8,19 @@ import java.util.List;
  * A test input inspired by MUSE project.
  */
 public class SortContainer {
-/*
-  public static void main(String[] args) {
-    List<Integer> list = makeAListOfLengthAtMost100(20);
-    List<Integer> sorted = sort(list);
-    for (int elem : sorted) {
-      System.out.println(elem);
-    }
+
+  private SortContainer() {
   }
-*/
+
+  /*
+    public static void main(String[] args) {
+      List<Integer> list = makeAListOfLengthAtMost100(20);
+      List<Integer> sorted = sort(list);
+      for (int elem : sorted) {
+        System.out.println(elem);
+      }
+    }
+  */
   public static List<Integer> sortIntegerList(List<Integer> unsorted) {
     List<Integer> list = new ArrayList<>(unsorted);
     Collections.sort(list);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.