### PR TITLE
Primitives should not be boxed just for "String" conversion

### DIFF
--- a/src/test/java/randoop/test/BiSort.java
+++ b/src/test/java/randoop/test/BiSort.java
@@ -89,7 +89,7 @@ public class BiSort {
       // check for options that require arguments
       if (arg.equals("-s")) {
         if (i < args.length) {
-          size = new Integer(args[i++]).intValue();
+          size = Integer.parseInt(args[i++]);
         } else {
           throw new Error("-l requires the number of levels");
         }

--- a/src/test/java/randoop/test/bh/BH.java
+++ b/src/test/java/randoop/test/bh/BH.java
@@ -113,13 +113,13 @@ public class BH {
       // check for options that require arguments
       if (arg.equals("-b")) {
         if (i < args.length) {
-          nbody = new Integer(args[i++]).intValue();
+          nbody = Integer.parseInt(args[i++]);
         } else {
           throw new Error("-l requires the number of levels");
         }
       } else if (arg.equals("-s")) {
         if (i < args.length) {
-          nsteps = new Integer(args[i++]).intValue();
+          nsteps = Integer.parseInt(args[i++]);
         } else {
           throw new Error("-l requires the number of levels");
         }

--- a/src/test/java/randoop/test/health/Health.java
+++ b/src/test/java/randoop/test/health/Health.java
@@ -80,19 +80,19 @@ public class Health {
       // check for options that require arguments
       if (arg.equals("-l")) {
         if (i < args.length) {
-          maxLevel = new Integer(args[i++]).intValue();
+          maxLevel = Integer.parseInt(args[i++]);
         } else {
           throw new Error("-l requires the number of levels");
         }
       } else if (arg.equals("-t")) {
         if (i < args.length) {
-          maxTime = new Integer(args[i++]).intValue();
+          maxTime = Integer.parseInt(args[i++]);
         } else {
           throw new Error("-t requires the amount of time");
         }
       } else if (arg.equals("-s")) {
         if (i < args.length) {
-          seed = new Integer(args[i++]).intValue();
+          seed = Integer.parseInt(args[i++]);
         } else {
           throw new Error("-s requires a seed value");
         }

--- a/src/test/java/randoop/test/mst/MST.java
+++ b/src/test/java/randoop/test/mst/MST.java
@@ -146,7 +146,7 @@ public class MST {
 
       if (arg.equals("-v")) {
         if (i < args.length) {
-          vertices = new Integer(args[i++]).intValue();
+          vertices = Integer.parseInt(args[i++]);
         } else throw new RuntimeException("-v requires the number of vertices");
       } else if (arg.equals("-p")) {
         printResult = true;

--- a/src/test/java/randoop/test/perimeter/Perimeter.java
+++ b/src/test/java/randoop/test/perimeter/Perimeter.java
@@ -82,7 +82,7 @@ public class Perimeter {
 
       if (arg.equals("-l")) {
         if (i < args.length) {
-          levels = new Integer(args[i++]).intValue();
+          levels = Integer.parseInt(args[i++]);
         } else {
           throw new Error("-l requires the number of levels");
         }

--- a/src/test/java/randoop/test/treeadd/TreeAdd.java
+++ b/src/test/java/randoop/test/treeadd/TreeAdd.java
@@ -66,7 +66,7 @@ public class TreeAdd {
 
       if (arg.equals("-l")) {
         if (i < args.length) {
-          levels = new Integer(args[i++]).intValue();
+          levels = Integer.parseInt(args[i++]);
         } else throw new RuntimeException("-l requires the number of levels");
       } else if (arg.equals("-p")) {
         printResult = true;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2131 - “Primitives should not be boxed just for "String" conversion”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2131
Please let me know if you have any questions.
Ayman Abdelghany.