### PR TITLE
Array designators "[]" should be on the type, not the variable

### DIFF
--- a/src/main/java/randoop/util/ClassFileConstants.java
+++ b/src/main/java/randoop/util/ClassFileConstants.java
@@ -109,7 +109,7 @@ public class ClassFileConstants {
    * @param args  the command line arguments
    * @throws IOException if an error occurs in writing the constants
    */
-  public static void main(String args[]) throws IOException {
+  public static void main(String[] args) throws IOException {
     for (String classname : args) {
       System.out.println(getConstants(classname));
     }

--- a/src/test/java/randoop/test/BiSort.java
+++ b/src/test/java/randoop/test/BiSort.java
@@ -31,7 +31,7 @@ public class BiSort {
    * The main routine which creates a tree and sorts it a couple of times.
    * @param args the command line arguments
    **/
-  public static final void main(String args[]) {
+  public static final void main(String[] args) {
     parseCmdLine(args);
 
     if (printMsgs) System.out.println("Bisort with " + size + " values");
@@ -79,7 +79,7 @@ public class BiSort {
    * Parse the command line options.
    * @param args the command line options.
    **/
-  private static final void parseCmdLine(String args[]) {
+  private static final void parseCmdLine(String[] args) {
     int i = 0;
     String arg;
 

--- a/src/test/java/randoop/test/bh/BH.java
+++ b/src/test/java/randoop/test/bh/BH.java
@@ -38,7 +38,7 @@ public class BH {
   static double DTIME = 0.0125;
   private static double TSTOP = 2.0;
 
-  public static final void main(String args[]) {
+  public static final void main(String[] args) {
     parseCmdLine(args);
 
     if (printMsgs) System.out.println("nbody = " + nbody);
@@ -104,7 +104,7 @@ public class BH {
    * Parse the command line options.
    * @param args the command line options.
    **/
-  private static final void parseCmdLine(String args[]) {
+  private static final void parseCmdLine(String[] args) {
     int i = 0;
     String arg;
     while (i < args.length && args[i].startsWith("-")) {

--- a/src/test/java/randoop/test/bh/MathVector.java
+++ b/src/test/java/randoop/test/bh/MathVector.java
@@ -13,7 +13,7 @@ public class MathVector implements Cloneable {
   /**
    * An array containing the values in the vector.
    **/
-  private double data[];
+  private double[] data;
 
   /**
    * Construct an empty 3 dimensional vector for use in Barnes-Hut algorithm.

--- a/src/test/java/randoop/test/health/Health.java
+++ b/src/test/java/randoop/test/health/Health.java
@@ -37,7 +37,7 @@ public class Health {
    * health-care system and executes the simulation for a specified time.
    * @param args the command line arguments
    **/
-  public static final void main(String args[]) {
+  public static final void main(String[] args) {
     parseCmdLine(args);
 
     long start0 = System.currentTimeMillis();
@@ -71,7 +71,7 @@ public class Health {
     System.out.println("Done!");
   }
 
-  private static final void parseCmdLine(String args[]) {
+  private static final void parseCmdLine(String[] args) {
     String arg;
     int i = 0;
     while (i < args.length && args[i].startsWith("-")) {

--- a/src/test/java/randoop/test/health/Village.java
+++ b/src/test/java/randoop/test/health/Village.java
@@ -89,7 +89,7 @@ public class Village {
    **/
   public List simulate() {
     // the list of patients refered from each child village
-    List val[] = new List[4];
+    List[] val = new List[4];
 
     for (int i = 3; i >= 0; i--) {
       Village v = forward[i];
@@ -127,7 +127,7 @@ public class Village {
    * @return a summary of the simulation results for the village
    **/
   public Results getResults() {
-    Results fval[] = new Results[4];
+    Results[] fval = new Results[4];
     for (int i = 3; i >= 0; i--) {
       Village v = forward[i];
       if (v != null) {

--- a/src/test/java/randoop/test/issta2006/FibHeap.java
+++ b/src/test/java/randoop/test/issta2006/FibHeap.java
@@ -120,7 +120,7 @@ public class FibHeap {
 
   private void consolidate() {
     int D = n + 1;
-    Node A[] = new Node[D];
+    Node[] A = new Node[D];
     for (int i = 0; i < D; i++) {
       gen(3, A[i], null);
       A[i] = null;
@@ -340,7 +340,7 @@ public class FibHeap {
     return heap;
   }
 
-  public static void main(String Argv[]) {
+  public static void main(String[] Argv) {
     FibHeap h = new FibHeap();
 
     h.insert(3);

--- a/src/test/java/randoop/test/mst/Hashtable.java
+++ b/src/test/java/randoop/test/mst/Hashtable.java
@@ -1,7 +1,7 @@
 package randoop.test.mst;
 
 public class Hashtable {
-  protected HashEntry array[];
+  protected HashEntry[] array;
   protected int size;
 
   public Hashtable(int sz) {

--- a/src/test/java/randoop/test/mst/MST.java
+++ b/src/test/java/randoop/test/mst/MST.java
@@ -26,7 +26,7 @@ public class MST {
    **/
   private static boolean printMsgs = false;
 
-  public static void main(String args[]) {
+  public static void main(String[] args) {
     parseCmdLine(args);
 
     if (printMsgs) System.out.println("Making graph of size " + vertices);
@@ -137,7 +137,7 @@ public class MST {
    * Parse the command line options.
    * @param args the command line options.
    **/
-  private static final void parseCmdLine(String args[]) {
+  private static final void parseCmdLine(String[] args) {
     int i = 0;
     String arg;
 

--- a/src/test/java/randoop/test/perimeter/Perimeter.java
+++ b/src/test/java/randoop/test/perimeter/Perimeter.java
@@ -35,7 +35,7 @@ public class Perimeter {
    * The entry point to computing the perimeter of an image.
    * @param args the command line arguments
    **/
-  public static void main(String args[]) {
+  public static void main(String[] args) {
 
     parseCmdLine(args);
 
@@ -73,7 +73,7 @@ public class Perimeter {
    * Parse the command line options.
    * @param args the command line options.
    **/
-  private static final void parseCmdLine(String args[]) {
+  private static final void parseCmdLine(String[] args) {
     int i = 0;
     String arg;
 

--- a/src/test/java/randoop/test/symexamples/Collections.java
+++ b/src/test/java/randoop/test/symexamples/Collections.java
@@ -984,7 +984,7 @@ public class Collections {
       }
 
       @Override
-      public Object[] toArray(final Object a[]) {
+      public Object[] toArray(final Object[] a) {
         final Object[] arr =
             c.toArray(
                 a.length == 0

--- a/src/test/java/randoop/test/symexamples/HeapArray.java
+++ b/src/test/java/randoop/test/symexamples/HeapArray.java
@@ -40,7 +40,7 @@ public class HeapArray {
   public boolean insert(Comparable element) {
     if ((((size >= array.length) && ++randoopCoverageInfo.branchTrue[6] != 0)
         || ++randoopCoverageInfo.branchFalse[6] == 0)) {
-      Comparable temp[] = new Comparable[2 * array.length + 1];
+      Comparable[] temp = new Comparable[2 * array.length + 1];
       for (int i = 0;
           (((i < size) && ++randoopCoverageInfo.branchTrue[5] != 0)
               || ++randoopCoverageInfo.branchFalse[5] == 0);

--- a/src/test/java/randoop/test/symexamples/List.java
+++ b/src/test/java/randoop/test/symexamples/List.java
@@ -14,7 +14,7 @@ public interface List extends Collection {
 
   Object[] toArray();
 
-  Object[] toArray(Object a[]);
+  Object[] toArray(Object[] a);
 
   boolean add(Object o);
 

--- a/src/test/java/randoop/test/treeadd/TreeAdd.java
+++ b/src/test/java/randoop/test/treeadd/TreeAdd.java
@@ -32,7 +32,7 @@ public class TreeAdd {
    * The main routine which creates a tree and traverses it.
    * @param args the arguments to the program
    **/
-  public static void main(String args[]) {
+  public static void main(String[] args) {
     parseCmdLine(args);
 
     long start0 = System.currentTimeMillis();
@@ -57,7 +57,7 @@ public class TreeAdd {
    * Parse the command line options.
    * @param args the command line options.
    **/
-  private static final void parseCmdLine(String args[]) {
+  private static final void parseCmdLine(String[] args) {
     int i = 0;
     String arg;
 

--- a/src/testinput/java/java2/util2/AbstractCollection.java
+++ b/src/testinput/java/java2/util2/AbstractCollection.java
@@ -156,7 +156,7 @@ public abstract class AbstractCollection implements Collection {
    *         is not a supertype of the runtime type of every element in this
    *         collection.
    */
-  public Object[] toArray(Object a[]) {
+  public Object[] toArray(Object[] a) {
     int size = size();
     if (a.length < size)
       a = (Object[]) java.lang.reflect.Array.newInstance(a.getClass().getComponentType(), size);

--- a/src/testinput/java/java2/util2/ArrayList.java
+++ b/src/testinput/java/java2/util2/ArrayList.java
@@ -86,7 +86,7 @@ public class ArrayList extends AbstractList
    * The array buffer into which the elements of the ArrayList are stored.
    * The capacity of the ArrayList is the length of this array buffer.
    */
-  private transient Object elementData[];
+  private transient Object[] elementData;
 
   /**
    * The size of the ArrayList (the number of elements it contains).
@@ -141,7 +141,7 @@ public class ArrayList extends AbstractList
     modCount++;
     int oldCapacity = elementData.length;
     if (size < oldCapacity) {
-      Object oldData[] = elementData;
+      Object[] oldData = elementData;
       elementData = new Object[size];
       System.arraycopy(oldData, 0, elementData, 0, size);
     }
@@ -158,7 +158,7 @@ public class ArrayList extends AbstractList
     modCount++;
     int oldCapacity = elementData.length;
     if (minCapacity > oldCapacity) {
-      Object oldData[] = elementData;
+      Object[] oldData = elementData;
       int newCapacity = (oldCapacity * 3) / 2 + 1;
       if (newCapacity < minCapacity) newCapacity = minCapacity;
       elementData = new Object[newCapacity];
@@ -284,7 +284,7 @@ public class ArrayList extends AbstractList
    * @throws ArrayStoreException if the runtime type of a is not a supertype
    *         of the runtime type of every element in this list.
    */
-  public Object[] toArray(Object a[]) {
+  public Object[] toArray(Object[] a) {
     if (a.length < size)
       a = (Object[]) java.lang.reflect.Array.newInstance(a.getClass().getComponentType(), size);
 

--- a/src/testinput/java/java2/util2/Arrays.java
+++ b/src/testinput/java/java2/util2/Arrays.java
@@ -372,7 +372,7 @@ public class Arrays {
     sort2(a, fromIndex, toIndex);
   }
 
-  private static void sort2(double a[], int fromIndex, int toIndex) {
+  private static void sort2(double[] a, int fromIndex, int toIndex) {
     final long NEG_ZERO_BITS = Double.doubleToLongBits(-0.0d);
     /*
      * The sort is done in three phases to avoid the expense of using
@@ -414,7 +414,7 @@ public class Arrays {
     }
   }
 
-  private static void sort2(float a[], int fromIndex, int toIndex) {
+  private static void sort2(float[] a, int fromIndex, int toIndex) {
     final int NEG_ZERO_BITS = Float.floatToIntBits(-0.0f);
     /*
      * The sort is done in three phases to avoid the expense of using
@@ -464,7 +464,7 @@ public class Arrays {
   /**
    * Sorts the specified sub-array of longs into ascending order.
    */
-  private static void sort1(long x[], int off, int len) {
+  private static void sort1(long[] x, int off, int len) {
     // Insertion sort on smallest arrays
     if (len < 7) {
       for (int i = off; i < len + off; i++)
@@ -517,7 +517,7 @@ public class Arrays {
   /**
    * Swaps x[a] with x[b].
    */
-  private static void swap(long x[], int a, int b) {
+  private static void swap(long[] x, int a, int b) {
     long t = x[a];
     x[a] = x[b];
     x[b] = t;
@@ -526,14 +526,14 @@ public class Arrays {
   /**
    * Swaps x[a .. (a+n-1)] with x[b .. (b+n-1)].
    */
-  private static void vecswap(long x[], int a, int b, int n) {
+  private static void vecswap(long[] x, int a, int b, int n) {
     for (int i = 0; i < n; i++, a++, b++) swap(x, a, b);
   }
 
   /**
    * Returns the index of the median of the three indexed longs.
    */
-  private static int med3(long x[], int a, int b, int c) {
+  private static int med3(long[] x, int a, int b, int c) {
     return (x[a] < x[b]
         ? (x[b] < x[c] ? b : x[a] < x[c] ? c : a)
         : (x[b] > x[c] ? b : x[a] > x[c] ? c : a));
@@ -542,7 +542,7 @@ public class Arrays {
   /**
    * Sorts the specified sub-array of integers into ascending order.
    */
-  private static void sort1(int x[], int off, int len) {
+  private static void sort1(int[] x, int off, int len) {
     // Insertion sort on smallest arrays
     if (len < 7) {
       for (int i = off; i < len + off; i++)
@@ -595,7 +595,7 @@ public class Arrays {
   /**
    * Swaps x[a] with x[b].
    */
-  private static void swap(int x[], int a, int b) {
+  private static void swap(int[] x, int a, int b) {
     int t = x[a];
     x[a] = x[b];
     x[b] = t;
@@ -604,14 +604,14 @@ public class Arrays {
   /**
    * Swaps x[a .. (a+n-1)] with x[b .. (b+n-1)].
    */
-  private static void vecswap(int x[], int a, int b, int n) {
+  private static void vecswap(int[] x, int a, int b, int n) {
     for (int i = 0; i < n; i++, a++, b++) swap(x, a, b);
   }
 
   /**
    * Returns the index of the median of the three indexed integers.
    */
-  private static int med3(int x[], int a, int b, int c) {
+  private static int med3(int[] x, int a, int b, int c) {
     return (x[a] < x[b]
         ? (x[b] < x[c] ? b : x[a] < x[c] ? c : a)
         : (x[b] > x[c] ? b : x[a] > x[c] ? c : a));
@@ -620,7 +620,7 @@ public class Arrays {
   /**
    * Sorts the specified sub-array of shorts into ascending order.
    */
-  private static void sort1(short x[], int off, int len) {
+  private static void sort1(short[] x, int off, int len) {
     // Insertion sort on smallest arrays
     if (len < 7) {
       for (int i = off; i < len + off; i++)
@@ -673,7 +673,7 @@ public class Arrays {
   /**
    * Swaps x[a] with x[b].
    */
-  private static void swap(short x[], int a, int b) {
+  private static void swap(short[] x, int a, int b) {
     short t = x[a];
     x[a] = x[b];
     x[b] = t;
@@ -682,14 +682,14 @@ public class Arrays {
   /**
    * Swaps x[a .. (a+n-1)] with x[b .. (b+n-1)].
    */
-  private static void vecswap(short x[], int a, int b, int n) {
+  private static void vecswap(short[] x, int a, int b, int n) {
     for (int i = 0; i < n; i++, a++, b++) swap(x, a, b);
   }
 
   /**
    * Returns the index of the median of the three indexed shorts.
    */
-  private static int med3(short x[], int a, int b, int c) {
+  private static int med3(short[] x, int a, int b, int c) {
     return (x[a] < x[b]
         ? (x[b] < x[c] ? b : x[a] < x[c] ? c : a)
         : (x[b] > x[c] ? b : x[a] > x[c] ? c : a));
@@ -698,7 +698,7 @@ public class Arrays {
   /**
    * Sorts the specified sub-array of chars into ascending order.
    */
-  private static void sort1(char x[], int off, int len) {
+  private static void sort1(char[] x, int off, int len) {
     // Insertion sort on smallest arrays
     if (len < 7) {
       for (int i = off; i < len + off; i++)
@@ -751,7 +751,7 @@ public class Arrays {
   /**
    * Swaps x[a] with x[b].
    */
-  private static void swap(char x[], int a, int b) {
+  private static void swap(char[] x, int a, int b) {
     char t = x[a];
     x[a] = x[b];
     x[b] = t;
@@ -760,14 +760,14 @@ public class Arrays {
   /**
    * Swaps x[a .. (a+n-1)] with x[b .. (b+n-1)].
    */
-  private static void vecswap(char x[], int a, int b, int n) {
+  private static void vecswap(char[] x, int a, int b, int n) {
     for (int i = 0; i < n; i++, a++, b++) swap(x, a, b);
   }
 
   /**
    * Returns the index of the median of the three indexed chars.
    */
-  private static int med3(char x[], int a, int b, int c) {
+  private static int med3(char[] x, int a, int b, int c) {
     return (x[a] < x[b]
         ? (x[b] < x[c] ? b : x[a] < x[c] ? c : a)
         : (x[b] > x[c] ? b : x[a] > x[c] ? c : a));
@@ -776,7 +776,7 @@ public class Arrays {
   /**
    * Sorts the specified sub-array of bytes into ascending order.
    */
-  private static void sort1(byte x[], int off, int len) {
+  private static void sort1(byte[] x, int off, int len) {
     // Insertion sort on smallest arrays
     if (len < 7) {
       for (int i = off; i < len + off; i++)
@@ -829,7 +829,7 @@ public class Arrays {
   /**
    * Swaps x[a] with x[b].
    */
-  private static void swap(byte x[], int a, int b) {
+  private static void swap(byte[] x, int a, int b) {
     byte t = x[a];
     x[a] = x[b];
     x[b] = t;
@@ -838,14 +838,14 @@ public class Arrays {
   /**
    * Swaps x[a .. (a+n-1)] with x[b .. (b+n-1)].
    */
-  private static void vecswap(byte x[], int a, int b, int n) {
+  private static void vecswap(byte[] x, int a, int b, int n) {
     for (int i = 0; i < n; i++, a++, b++) swap(x, a, b);
   }
 
   /**
    * Returns the index of the median of the three indexed bytes.
    */
-  private static int med3(byte x[], int a, int b, int c) {
+  private static int med3(byte[] x, int a, int b, int c) {
     return (x[a] < x[b]
         ? (x[b] < x[c] ? b : x[a] < x[c] ? c : a)
         : (x[b] > x[c] ? b : x[a] > x[c] ? c : a));
@@ -854,7 +854,7 @@ public class Arrays {
   /**
    * Sorts the specified sub-array of doubles into ascending order.
    */
-  private static void sort1(double x[], int off, int len) {
+  private static void sort1(double[] x, int off, int len) {
     // Insertion sort on smallest arrays
     if (len < 7) {
       for (int i = off; i < len + off; i++)
@@ -907,7 +907,7 @@ public class Arrays {
   /**
    * Swaps x[a] with x[b].
    */
-  private static void swap(double x[], int a, int b) {
+  private static void swap(double[] x, int a, int b) {
     double t = x[a];
     x[a] = x[b];
     x[b] = t;
@@ -916,14 +916,14 @@ public class Arrays {
   /**
    * Swaps x[a .. (a+n-1)] with x[b .. (b+n-1)].
    */
-  private static void vecswap(double x[], int a, int b, int n) {
+  private static void vecswap(double[] x, int a, int b, int n) {
     for (int i = 0; i < n; i++, a++, b++) swap(x, a, b);
   }
 
   /**
    * Returns the index of the median of the three indexed doubles.
    */
-  private static int med3(double x[], int a, int b, int c) {
+  private static int med3(double[] x, int a, int b, int c) {
     return (x[a] < x[b]
         ? (x[b] < x[c] ? b : x[a] < x[c] ? c : a)
         : (x[b] > x[c] ? b : x[a] > x[c] ? c : a));
@@ -932,7 +932,7 @@ public class Arrays {
   /**
    * Sorts the specified sub-array of floats into ascending order.
    */
-  private static void sort1(float x[], int off, int len) {
+  private static void sort1(float[] x, int off, int len) {
     // Insertion sort on smallest arrays
     if (len < 7) {
       for (int i = off; i < len + off; i++)
@@ -985,7 +985,7 @@ public class Arrays {
   /**
    * Swaps x[a] with x[b].
    */
-  private static void swap(float x[], int a, int b) {
+  private static void swap(float[] x, int a, int b) {
     float t = x[a];
     x[a] = x[b];
     x[b] = t;
@@ -994,14 +994,14 @@ public class Arrays {
   /**
    * Swaps x[a .. (a+n-1)] with x[b .. (b+n-1)].
    */
-  private static void vecswap(float x[], int a, int b, int n) {
+  private static void vecswap(float[] x, int a, int b, int n) {
     for (int i = 0; i < n; i++, a++, b++) swap(x, a, b);
   }
 
   /**
    * Returns the index of the median of the three indexed floats.
    */
-  private static int med3(float x[], int a, int b, int c) {
+  private static int med3(float[] x, int a, int b, int c) {
     return (x[a] < x[b]
         ? (x[b] < x[c] ? b : x[a] < x[c] ? c : a)
         : (x[b] > x[c] ? b : x[a] > x[c] ? c : a));
@@ -1029,7 +1029,7 @@ public class Arrays {
    * @see Comparable
    */
   public static void sort(Object[] a) {
-    Object aux[] = (Object[]) a.clone();
+    Object[] aux = (Object[]) a.clone();
     mergeSort(aux, a, 0, a.length, 0);
   }
 
@@ -1067,7 +1067,7 @@ public class Arrays {
    */
   public static void sort(Object[] a, int fromIndex, int toIndex) {
     rangeCheck(a.length, fromIndex, toIndex);
-    Object aux[] = (Object[]) cloneSubarray(a, fromIndex, toIndex);
+    Object[] aux = (Object[]) cloneSubarray(a, fromIndex, toIndex);
     mergeSort(aux, a, fromIndex, toIndex, -fromIndex);
   }
 
@@ -1095,7 +1095,7 @@ public class Arrays {
    * high is the end index in dest to end sorting
    * off is the offset to generate corresponding low, high in src
    */
-  private static void mergeSort(Object src[], Object dest[], int low, int high, int off) {
+  private static void mergeSort(Object[] src, Object[] dest, int low, int high, int off) {
     int length = high - low;
 
     // Insertion sort on smallest arrays
@@ -1133,7 +1133,7 @@ public class Arrays {
   /**
    * Swaps x[a] with x[b].
    */
-  private static void swap(Object x[], int a, int b) {
+  private static void swap(Object[] x, int a, int b) {
     Object t = x[a];
     x[a] = x[b];
     x[b] = t;
@@ -1163,7 +1163,7 @@ public class Arrays {
    * @see Comparator
    */
   public static void sort(Object[] a, Comparator c) {
-    Object aux[] = (Object[]) a.clone();
+    Object[] aux = (Object[]) a.clone();
     if (c == null) mergeSort(aux, a, 0, a.length, 0);
     else mergeSort(aux, a, 0, a.length, 0, c);
   }
@@ -1202,7 +1202,7 @@ public class Arrays {
    */
   public static void sort(Object[] a, int fromIndex, int toIndex, Comparator c) {
     rangeCheck(a.length, fromIndex, toIndex);
-    Object aux[] = (Object[]) cloneSubarray(a, fromIndex, toIndex);
+    Object[] aux = (Object[]) cloneSubarray(a, fromIndex, toIndex);
     if (c == null) mergeSort(aux, a, fromIndex, toIndex, -fromIndex);
     else mergeSort(aux, a, fromIndex, toIndex, -fromIndex, c);
   }
@@ -1215,7 +1215,7 @@ public class Arrays {
    * off is the offset into src corresponding to low in dest
    */
   private static void mergeSort(
-      Object src[], Object dest[], int low, int high, int off, Comparator c) {
+          Object[] src, Object[] dest, int low, int high, int off, Comparator c) {
     int length = high - low;
 
     // Insertion sort on smallest arrays
@@ -1700,7 +1700,7 @@ public class Arrays {
    * @param a2 the other array to be tested for equality.
    * @return <tt>true</tt> if the two arrays are equal.
    */
-  public static boolean equals(short[] a, short a2[]) {
+  public static boolean equals(short[] a, short[] a2) {
     if (a == a2) return true;
     if (a == null || a2 == null) return false;
 

--- a/src/testinput/java/java2/util2/BitSet.java
+++ b/src/testinput/java/java2/util2/BitSet.java
@@ -60,7 +60,7 @@ public class BitSet implements Cloneable, java.io.Serializable {
    *
    * @serial
    */
-  private long bits[]; // this should be called unit[]
+  private long[] bits; // this should be called unit[]
 
   /**
    * The number of units in the logical size of this BitSet.
@@ -130,7 +130,7 @@ public class BitSet implements Cloneable, java.io.Serializable {
     if (bits.length < unitsRequired) {
       // Allocate larger of doubled size or required size
       int request = Math.max(2 * bits.length, unitsRequired);
-      long newBits[] = new long[request];
+      long[] newBits = new long[request];
       System.arraycopy(bits, 0, newBits, 0, unitsInUse);
       bits = newBits;
     }
@@ -557,16 +557,16 @@ public class BitSet implements Cloneable, java.io.Serializable {
    * trailingZeroTable[i] is the number of trailing zero bits in the binary
    * representaion of i.
    */
-  private final static byte trailingZeroTable[] = {
-    -25, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1,
-    0, 5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1,
-    0, 6, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1,
-    0, 5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1,
-    0, 7, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1,
-    0, 5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1,
-    0, 6, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1,
-    0, 5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1,
-    0
+  private final static byte[] trailingZeroTable = {
+          -25, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1,
+          0, 5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1,
+          0, 6, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1,
+          0, 5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1,
+          0, 7, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1,
+          0, 5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1,
+          0, 6, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1,
+          0, 5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1,
+          0
   };
 
   /**

--- a/src/testinput/java/java2/util2/Collection.java
+++ b/src/testinput/java/java2/util2/Collection.java
@@ -184,7 +184,7 @@ public interface Collection {
    *         collection.
    * @throws NullPointerException if the specified array is <tt>null</tt>.
    */
-  Object[] toArray(Object a[]);
+  Object[] toArray(Object[] a);
 
   // Modification Operations
 

--- a/src/testinput/java/java2/util2/Collections.java
+++ b/src/testinput/java/java2/util2/Collections.java
@@ -108,7 +108,7 @@ public class Collections {
    * @see Comparable
    */
   public static void sort(List list) {
-    Object a[] = list.toArray();
+    Object[] a = list.toArray();
     Arrays.sort(a);
     ListIterator i = list.listIterator();
     for (int j = 0; j < a.length; j++) {
@@ -150,7 +150,7 @@ public class Collections {
    * @see Comparator
    */
   public static void sort(List list, Comparator c) {
-    Object a[] = list.toArray();
+    Object[] a = list.toArray();
     Arrays.sort(a, c);
     ListIterator i = list.listIterator();
     for (int j = 0; j < a.length; j++) {
@@ -411,7 +411,7 @@ public class Collections {
     if (size < SHUFFLE_THRESHOLD || list instanceof RandomAccess) {
       for (int i = size; i > 1; i--) swap(list, i - 1, rnd.nextInt(i));
     } else {
-      Object arr[] = list.toArray();
+      Object[] arr = list.toArray();
 
       // Shuffle array
       for (int i = size; i > 1; i--) swap(arr, i - 1, rnd.nextInt(i));
@@ -1397,7 +1397,7 @@ public class Collections {
         return a;
       }
 
-      public Object[] toArray(Object a[]) {
+      public Object[] toArray(Object[] a) {
         // We don't pass a to c.toArray, to avoid window of
         // vulnerability wherein an unscrupulous multithreaded client
         // could get his hands on raw (unwrapped) Entries from c.

--- a/src/testinput/java/java2/util2/HashMap.java
+++ b/src/testinput/java/java2/util2/HashMap.java
@@ -578,7 +578,7 @@ public class HashMap extends AbstractMap implements Map, Cloneable, Serializable
    */
   public void clear() {
     modCount++;
-    Entry tab[] = table;
+    Entry[] tab = table;
     for (int i = 0; i < tab.length; i++) tab[i] = null;
     size = 0;
   }
@@ -594,7 +594,7 @@ public class HashMap extends AbstractMap implements Map, Cloneable, Serializable
   public boolean containsValue(Object value) {
     if (value == null) return containsNullValue();
 
-    Entry tab[] = table;
+    Entry[] tab = table;
     for (int i = 0; i < tab.length; i++)
       for (Entry e = tab[i]; e != null; e = e.next) if (value.equals(e.value)) return true;
     return false;
@@ -604,7 +604,7 @@ public class HashMap extends AbstractMap implements Map, Cloneable, Serializable
    * Special-case code for containsValue with null argument
    **/
   private boolean containsNullValue() {
-    Entry tab[] = table;
+    Entry[] tab = table;
     for (int i = 0; i < tab.length; i++)
       for (Entry e = tab[i]; e != null; e = e.next) if (e.value == null) return true;
     return false;

--- a/src/testinput/java/java2/util2/Hashtable.java
+++ b/src/testinput/java/java2/util2/Hashtable.java
@@ -106,7 +106,7 @@ public class Hashtable extends Dictionary implements Map, Cloneable, java.io.Ser
   /**
    * The hash table data.
    */
-  private transient Entry table[];
+  private transient Entry[] table;
 
   /**
    * The total number of entries in the hash table.
@@ -266,7 +266,7 @@ public class Hashtable extends Dictionary implements Map, Cloneable, java.io.Ser
       throw new NullPointerException();
     }
 
-    Entry tab[] = table;
+    Entry[] tab = table;
     for (int i = tab.length; i-- > 0; ) {
       for (Entry e = tab[i]; e != null; e = e.next) {
         if (e.value.equals(value)) {
@@ -305,7 +305,7 @@ public class Hashtable extends Dictionary implements Map, Cloneable, java.io.Ser
    * @see     #contains(Object)
    */
   public synchronized boolean containsKey(Object key) {
-    Entry tab[] = table;
+    Entry[] tab = table;
     int hash = key.hashCode();
     int index = (hash & 0x7FFFFFFF) % tab.length;
     for (Entry e = tab[index]; e != null; e = e.next) {
@@ -327,7 +327,7 @@ public class Hashtable extends Dictionary implements Map, Cloneable, java.io.Ser
    * @see     #put(Object, Object)
    */
   public synchronized Object get(Object key) {
-    Entry tab[] = table;
+    Entry[] tab = table;
     int hash = key.hashCode();
     int index = (hash & 0x7FFFFFFF) % tab.length;
     for (Entry e = tab[index]; e != null; e = e.next) {
@@ -347,10 +347,10 @@ public class Hashtable extends Dictionary implements Map, Cloneable, java.io.Ser
    */
   protected void rehash() {
     int oldCapacity = table.length;
-    Entry oldMap[] = table;
+    Entry[] oldMap = table;
 
     int newCapacity = oldCapacity * 2 + 1;
-    Entry newMap[] = new Entry[newCapacity];
+    Entry[] newMap = new Entry[newCapacity];
 
     modCount++;
     threshold = (int) (newCapacity * loadFactor);
@@ -392,7 +392,7 @@ public class Hashtable extends Dictionary implements Map, Cloneable, java.io.Ser
     }
 
     // Makes sure the key is not already in the hashtable.
-    Entry tab[] = table;
+    Entry[] tab = table;
     int hash = key.hashCode();
     int index = (hash & 0x7FFFFFFF) % tab.length;
     for (Entry e = tab[index]; e != null; e = e.next) {
@@ -429,7 +429,7 @@ public class Hashtable extends Dictionary implements Map, Cloneable, java.io.Ser
    * @throws  NullPointerException  if the key is <code>null</code>.
    */
   public synchronized Object remove(Object key) {
-    Entry tab[] = table;
+    Entry[] tab = table;
     int hash = key.hashCode();
     int index = (hash & 0x7FFFFFFF) % tab.length;
     for (Entry e = tab[index], prev = null; e != null; prev = e, e = e.next) {
@@ -470,7 +470,7 @@ public class Hashtable extends Dictionary implements Map, Cloneable, java.io.Ser
    * Clears this hashtable so that it contains no keys.
    */
   public synchronized void clear() {
-    Entry tab[] = table;
+    Entry[] tab = table;
     modCount++;
     for (int index = tab.length; --index >= 0; ) tab[index] = null;
     count = 0;
@@ -620,7 +620,7 @@ public class Hashtable extends Dictionary implements Map, Cloneable, java.io.Ser
       if (!(o instanceof Map.Entry)) return false;
       Map.Entry entry = (Map.Entry) o;
       Object key = entry.getKey();
-      Entry tab[] = table;
+      Entry[] tab = table;
       int hash = key.hashCode();
       int index = (hash & 0x7FFFFFFF) % tab.length;
 
@@ -633,7 +633,7 @@ public class Hashtable extends Dictionary implements Map, Cloneable, java.io.Ser
       if (!(o instanceof Map.Entry)) return false;
       Map.Entry entry = (Map.Entry) o;
       Object key = entry.getKey();
-      Entry tab[] = table;
+      Entry[] tab = table;
       int hash = key.hashCode();
       int index = (hash & 0x7FFFFFFF) % tab.length;
 
@@ -754,7 +754,7 @@ public class Hashtable extends Dictionary implements Map, Cloneable, java.io.Ser
     if (count == 0 || loadFactor < 0) return h; // Returns zero
 
     loadFactor = -loadFactor; // Mark hashCode computation in progress
-    Entry tab[] = table;
+    Entry[] tab = table;
     for (int i = 0; i < tab.length; i++)
       for (Entry e = tab[i]; e != null; e = e.next) h += e.key.hashCode() ^ e.value.hashCode();
     loadFactor = -loadFactor; // Mark hashCode computation complete
@@ -915,7 +915,7 @@ public class Hashtable extends Dictionary implements Map, Cloneable, java.io.Ser
     public boolean hasMoreElements() {
       Entry e = entry;
       int i = index;
-      Entry t[] = table;
+      Entry[] t = table;
       /* Use locals for faster loop iteration */
       while (e == null && i > 0) {
         e = t[--i];
@@ -928,7 +928,7 @@ public class Hashtable extends Dictionary implements Map, Cloneable, java.io.Ser
     public Object nextElement() {
       Entry et = entry;
       int i = index;
-      Entry t[] = table;
+      Entry[] t = table;
       /* Use locals for faster loop iteration */
       while (et == null && i > 0) {
         et = t[--i];

--- a/src/testinput/java/java2/util2/IdentityHashMap.java
+++ b/src/testinput/java/java2/util2/IdentityHashMap.java
@@ -1063,7 +1063,7 @@ public class IdentityHashMap extends AbstractMap implements Map, java.io.Seriali
       return c.toArray();
     }
 
-    public Object[] toArray(Object a[]) {
+    public Object[] toArray(Object[] a) {
       Collection c = new ArrayList(size());
       for (Iterator i = iterator(); i.hasNext(); )
         c.add(new AbstractMap.SimpleEntry((Map.Entry) i.next()));

--- a/src/testinput/java/java2/util2/LinkedList.java
+++ b/src/testinput/java/java2/util2/LinkedList.java
@@ -622,7 +622,7 @@ public class LinkedList extends AbstractSequentialList
    *         supertype of the runtime type of every element in this list.
    * @throws NullPointerException if the specified array is null.
    */
-  public Object[] toArray(Object a[]) {
+  public Object[] toArray(Object[] a) {
     if (a.length < size)
       a = (Object[]) java.lang.reflect.Array.newInstance(a.getClass().getComponentType(), size);
     int i = 0;

--- a/src/testinput/java/java2/util2/List.java
+++ b/src/testinput/java/java2/util2/List.java
@@ -154,7 +154,7 @@ public interface List extends Collection {
    * 		  this list.
    * @throws NullPointerException if the specified array is <tt>null</tt>.
    */
-  Object[] toArray(Object a[]);
+  Object[] toArray(Object[] a);
 
   // Modification Operations
 

--- a/src/testinput/java/java2/util2/Set.java
+++ b/src/testinput/java/java2/util2/Set.java
@@ -126,7 +126,7 @@ public interface Set extends Collection {
    *            of the runtime type of every element in this set.
    * @throws NullPointerException if the specified array is <tt>null</tt>.
    */
-  Object[] toArray(Object a[]);
+  Object[] toArray(Object[] a);
 
   // Modification Operations
 

--- a/src/testinput/java/java2/util2/Vector.java
+++ b/src/testinput/java/java2/util2/Vector.java
@@ -64,12 +64,12 @@ public class Vector extends AbstractList
    * The array buffer into which the components of the vector are
    * stored. The capacity of the vector is the length of this array buffer,
    * and is at least large enough to contain all the vector's elements.<p>
-   *
+   * <p/>
    * Any array elements following the last element in the Vector are null.
    *
    * @serial
    */
-  protected Object elementData[];
+  protected Object[] elementData;
 
   /**
    * The number of valid components in this <tt>Vector</tt> object.
@@ -159,7 +159,7 @@ public class Vector extends AbstractList
    * @param   anArray   the array into which the components get copied.
    * @throws  NullPointerException if the given array is null.
    */
-  public synchronized void copyInto(Object anArray[]) {
+  public synchronized void copyInto(Object[] anArray) {
     System.arraycopy(elementData, 0, anArray, 0, elementCount);
   }
 
@@ -175,7 +175,7 @@ public class Vector extends AbstractList
     modCount++;
     int oldCapacity = elementData.length;
     if (elementCount < oldCapacity) {
-      Object oldData[] = elementData;
+      Object[] oldData = elementData;
       elementData = new Object[elementCount];
       System.arraycopy(oldData, 0, elementData, 0, elementCount);
     }
@@ -214,7 +214,7 @@ public class Vector extends AbstractList
   private void ensureCapacityHelper(int minCapacity) {
     int oldCapacity = elementData.length;
     if (minCapacity > oldCapacity) {
-      Object oldData[] = elementData;
+      Object[] oldData = elementData;
       int newCapacity =
           (capacityIncrement > 0) ? (oldCapacity + capacityIncrement) : (oldCapacity * 2);
       if (newCapacity < minCapacity) {
@@ -663,7 +663,7 @@ public class Vector extends AbstractList
    * @throws NullPointerException if the given array is null.
    * @since 1.2
    */
-  public synchronized Object[] toArray(Object a[]) {
+  public synchronized Object[] toArray(Object[] a) {
     if (a.length < elementCount)
       a =
           (Object[])

--- a/src/testinput/java/java2/util2/WeakHashMap.java
+++ b/src/testinput/java/java2/util2/WeakHashMap.java
@@ -562,7 +562,7 @@ public class WeakHashMap extends AbstractMap implements Map {
     while (queue.poll() != null) ;
 
     modCount++;
-    Entry tab[] = table;
+    Entry[] tab = table;
     for (int i = 0; i < tab.length; ++i) tab[i] = null;
     size = 0;
 
@@ -583,7 +583,7 @@ public class WeakHashMap extends AbstractMap implements Map {
   public boolean containsValue(Object value) {
     if (value == null) return containsNullValue();
 
-    Entry tab[] = getTable();
+    Entry[] tab = getTable();
     for (int i = tab.length; i-- > 0; )
       for (Entry e = tab[i]; e != null; e = e.next) if (value.equals(e.value)) return true;
     return false;
@@ -593,7 +593,7 @@ public class WeakHashMap extends AbstractMap implements Map {
    * Special-case code for containsValue with null argument
    */
   private boolean containsNullValue() {
-    Entry tab[] = getTable();
+    Entry[] tab = getTable();
     for (int i = tab.length; i-- > 0; )
       for (Entry e = tab[i]; e != null; e = e.next) if (e.value == null) return true;
     return false;
@@ -788,7 +788,7 @@ public class WeakHashMap extends AbstractMap implements Map {
       return c.toArray();
     }
 
-    public Object[] toArray(Object a[]) {
+    public Object[] toArray(Object[] a) {
       Collection c = new ArrayList(size());
       for (Iterator i = iterator(); i.hasNext(); ) c.add(i.next());
       return c.toArray(a);
@@ -834,7 +834,7 @@ public class WeakHashMap extends AbstractMap implements Map {
       return c.toArray();
     }
 
-    public Object[] toArray(Object a[]) {
+    public Object[] toArray(Object[] a) {
       Collection c = new ArrayList(size());
       for (Iterator i = iterator(); i.hasNext(); ) c.add(i.next());
       return c.toArray(a);
@@ -891,7 +891,7 @@ public class WeakHashMap extends AbstractMap implements Map {
       return c.toArray();
     }
 
-    public Object[] toArray(Object a[]) {
+    public Object[] toArray(Object[] a) {
       Collection c = new ArrayList(size());
       for (Iterator i = iterator(); i.hasNext(); )
         c.add(new AbstractMap.SimpleEntry((Map.Entry) i.next()));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1197 - “Array designators "[]" should be on the type, not the variable”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1197
Please let me know if you have any questions.
Ayman Abdelghany.