### PR TITLE
Using Collection.isEmpty() to test for emptiness

### DIFF
--- a/agent/mapcall/src/main/java/randoop/instrument/Premain.java
+++ b/agent/mapcall/src/main/java/randoop/instrument/Premain.java
@@ -153,7 +153,7 @@ public class Premain {
       List<URL> bcel_urls = get_resource_list(bcel_classname);
       List<URL> pag_urls = get_resource_list(pag_marker_classname);
 
-      if (pag_urls.size() == 0) {
+      if (pag_urls.isEmpty()) {
         System.err.printf(
             "%nBCEL must be in the classpath.  " + "Normally it is found in daikon.jar .%n");
         System.exit(1);

--- a/src/agenttest/java/randoop/instrument/CoveredClassTest.java
+++ b/src/agenttest/java/randoop/instrument/CoveredClassTest.java
@@ -62,8 +62,8 @@ public class CoveredClassTest {
     List<ExecutableSequence> eTests = testGenerator.getErrorTestSequences();
 
     System.out.println("number of regression tests: " + rTests.size());
-    assertTrue("should have some regression tests", rTests.size() > 0);
-    assertFalse("don't expect error tests", eTests.size() > 0);
+    assertTrue("should have some regression tests", !rTests.isEmpty());
+    assertFalse("don't expect error tests", !eTests.isEmpty());
 
     Class<?> ac = null;
     try {
@@ -105,8 +105,8 @@ public class CoveredClassTest {
     List<ExecutableSequence> eTests = testGenerator.getErrorTestSequences();
 
     System.out.println("number of regression tests: " + rTests.size());
-    assertTrue("should be no regression tests", rTests.size() == 0);
-    assertFalse("should be no error tests", eTests.size() > 0);
+    assertTrue("should be no regression tests", rTests.isEmpty());
+    assertFalse("should be no error tests", !eTests.isEmpty());
 
     Class<?> ac = null;
     try {
@@ -147,8 +147,8 @@ public class CoveredClassTest {
     List<ExecutableSequence> eTests = testGenerator.getErrorTestSequences();
 
     System.out.println("number of regression tests: " + rTests.size());
-    assertTrue("should have some regression tests", rTests.size() > 0);
-    assertFalse("don't expect error tests", eTests.size() > 0);
+    assertTrue("should have some regression tests", !rTests.isEmpty());
+    assertFalse("don't expect error tests", !eTests.isEmpty());
 
     Class<?> ac = null;
     try {

--- a/src/agenttest/java/randoop/instrument/SpecialCoveredClassTest.java
+++ b/src/agenttest/java/randoop/instrument/SpecialCoveredClassTest.java
@@ -156,8 +156,8 @@ public class SpecialCoveredClassTest {
     List<ExecutableSequence> eTests = testGenerator.getErrorTestSequences();
     //
     System.out.println("number of regression tests: " + rTests.size());
-    assertTrue("should have some regression tests", rTests.size() > 0);
-    assertFalse("don't expect error tests", eTests.size() > 0);
+    assertTrue("should have some regression tests", !rTests.isEmpty());
+    assertFalse("don't expect error tests", !eTests.isEmpty());
     //
     Class<?> at = null;
     try {

--- a/src/main/java/randoop/JavaFileWriter.java
+++ b/src/main/java/randoop/JavaFileWriter.java
@@ -19,7 +19,7 @@ public class JavaFileWriter {
   // Output is a set of .java files.
   public static void createJavaFiles(
       List<Sequence> sequences, String junitClassName, int testsPerFile) {
-    if (sequences.size() == 0) {
+    if (sequences.isEmpty()) {
       System.out.println("No sequences given to createJavaFiles. No files created.");
       return;
     }

--- a/src/main/java/randoop/generation/ForwardGenerator.java
+++ b/src/main/java/randoop/generation/ForwardGenerator.java
@@ -324,7 +324,7 @@ public class ForwardGenerator extends AbstractGenerator {
     // If parameterless statement, subsequence inputs
     // will all be redundant, so just remove it from list of statements.
     // XXX does this make sense? especially in presence of side-effects
-    if (operation.getInputTypes().size() == 0) {
+    if (operation.getInputTypes().isEmpty()) {
       operations.remove(operation);
     }
 
@@ -551,7 +551,7 @@ public class ForwardGenerator extends AbstractGenerator {
         // If any type-compatible variables found, pick one at random as the
         // i-th input to st.
         SimpleList<Integer> candidateVars2 = new ListOfLists<>(candidateVars);
-        if (candidateVars2.size() > 0) {
+        if (!candidateVars2.isEmpty()) {
           int randVarIdx = Randomness.nextRandomInt(candidateVars2.size());
           Integer randVar = candidateVars2.get(randVarIdx);
           variables.add(randVar);
@@ -602,7 +602,7 @@ public class ForwardGenerator extends AbstractGenerator {
       // inputTypes[i], and we are
       // allowed the use null values, use null. If we're not allowed, then
       // return with failure.
-      if (l.size() == 0) {
+      if (l.isEmpty()) {
         if (isReceiver || GenInputsAbstract.forbid_null) {
           if (Log.isLoggingOn())
             Log.logLine("forbid-null option is true. Failed to create new sequence.");

--- a/src/main/java/randoop/main/CommandHandler.java
+++ b/src/main/java/randoop/main/CommandHandler.java
@@ -121,7 +121,7 @@ public abstract class CommandHandler {
       out.println("}}}");
       out.println();
     }
-    if (fnotes != null && fnotes.size() > 0) {
+    if (fnotes != null && !fnotes.isEmpty()) {
       out.println("*Notes:*");
       out.println();
       for (String note : fnotes) {
@@ -167,7 +167,7 @@ public abstract class CommandHandler {
           Util.hangingParagraph("Example: " + fexample, Globals.COLWIDTH, Globals.INDENTWIDTH));
     }
     out.println();
-    if (fnotes != null && fnotes.size() > 0) {
+    if (fnotes != null && !fnotes.isEmpty()) {
       out.println("Notes:");
       out.println();
       for (int i = 0; i < fnotes.size(); i++) {

--- a/src/main/java/randoop/main/GenInputsAbstract.java
+++ b/src/main/java/randoop/main/GenInputsAbstract.java
@@ -645,7 +645,7 @@ public abstract class GenInputsAbstract extends CommandHandler {
           "Maximum sequence size must be greater than zero but was " + maxsize);
     }
 
-    if (literals_file.size() > 0 && literals_level == ClassLiteralsMode.NONE) {
+    if (!literals_file.isEmpty() && literals_level == ClassLiteralsMode.NONE) {
       throw new RuntimeException(
           "Invalid parameter combination: specified a class literal file but --use-class-literals=NONE");
     }

--- a/src/main/java/randoop/main/GenTests.java
+++ b/src/main/java/randoop/main/GenTests.java
@@ -149,7 +149,7 @@ public class GenTests extends GenInputsAbstract {
     executeInitializationRoutine(1);
 
     // Check that there are classes to test
-    if (classlist == null && methodlist == null && testclass.size() == 0) {
+    if (classlist == null && methodlist == null && testclass.isEmpty()) {
       System.out.println("You must specify some classes or methods to test.");
       System.out.println("Use the --classlist, --testclass, or --methodlist options.");
       System.exit(1);
@@ -218,7 +218,7 @@ public class GenTests extends GenInputsAbstract {
 
     List<ConcreteOperation> model = operationModel.getConcreteOperations();
 
-    if (model.size() == 0) {
+    if (model.isEmpty()) {
       Log.out.println("There are no methods to test. Exiting.");
       System.exit(1);
     }
@@ -360,7 +360,7 @@ public class GenTests extends GenInputsAbstract {
 
     if (!GenInputsAbstract.no_error_revealing_tests) {
       List<ExecutableSequence> errorSequences = explorer.getErrorTestSequences();
-      if (errorSequences.size() > 0) {
+      if (!errorSequences.isEmpty()) {
         if (!GenInputsAbstract.noprogressdisplay) {
           System.out.printf("%nError-revealing test output:%n");
           System.out.printf("Error-revealing test count: %d%n", errorSequences.size());
@@ -375,7 +375,7 @@ public class GenTests extends GenInputsAbstract {
 
     if (!GenInputsAbstract.no_regression_tests) {
       List<ExecutableSequence> regressionSequences = explorer.getRegressionSequences();
-      if (regressionSequences.size() > 0) {
+      if (!regressionSequences.isEmpty()) {
         if (!GenInputsAbstract.noprogressdisplay) {
           System.out.printf("%nRegression test output:%n");
           System.out.printf("Regression test count: %d%n", regressionSequences.size());
@@ -594,7 +594,7 @@ public class GenTests extends GenInputsAbstract {
 
     List<File> files = new ArrayList<>();
 
-    if (seqList.size() > 0) {
+    if (!seqList.isEmpty()) {
       List<List<ExecutableSequence>> seqPartition =
           CollectionsExt.<ExecutableSequence>chunkUp(new ArrayList<>(seqList), testsperfile);
 

--- a/src/main/java/randoop/operation/ConstructorCall.java
+++ b/src/main/java/randoop/operation/ConstructorCall.java
@@ -113,7 +113,7 @@ public final class ConstructorCall extends CallableOperation {
     Class<?> declaringClass = constructor.getDeclaringClass();
     boolean isNonStaticMember =
         (!Modifier.isStatic(declaringClass.getModifiers()) && declaringClass.isMemberClass());
-    assert Util.implies(isNonStaticMember, inputVars.size() > 0);
+    assert Util.implies(isNonStaticMember, !inputVars.isEmpty());
 
     // Note on isNonStaticMember: if a class is a non-static member class, the
     // runtime signature of the constructor will have an additional argument

--- a/src/main/java/randoop/reflection/OperationModel.java
+++ b/src/main/java/randoop/reflection/OperationModel.java
@@ -192,7 +192,7 @@ public class OperationModel extends ModelCollections {
   private void refineGenericClassTypes(Set<ConcreteType> inputTypes) throws RandoopTypeException {
     for (GenericClassType classType : genericClassTypes.keySet()) {
       List<Substitution> substitutions = getSubstitutions(inputTypes, classType);
-      assert  substitutions.size() > 0 : "didn't find types to satisfy bounds on generic";
+      assert !substitutions.isEmpty() : "didn't find types to satisfy bounds on generic";
       Substitution substitution = Randomness.randomMember(substitutions);
       GeneralType refinedClassType = classType.apply(substitution);
       if (! refinedClassType.isGeneric()) {

--- a/src/main/java/randoop/sequence/Sequence.java
+++ b/src/main/java/randoop/sequence/Sequence.java
@@ -429,7 +429,7 @@ public final class Sequence implements WeightedElement {
     this.lastStatementTypes = new ArrayList<>();
     this.lastStatementVariables = new ArrayList<>();
 
-    if (this.statements.size() > 0) {
+    if (!this.statements.isEmpty()) {
       int lastStatementIndex = this.statements.size() - 1;
       Statement lastStatement = this.statements.get(lastStatementIndex);
 
@@ -614,7 +614,7 @@ public final class Sequence implements WeightedElement {
         possibleIndices.add(getVariable(i));
       }
     }
-    if (possibleIndices.size() == 0) return null;
+    if (possibleIndices.isEmpty()) return null;
     return Randomness.randomMember(possibleIndices);
   }
 
@@ -760,7 +760,7 @@ public final class Sequence implements WeightedElement {
 
   // TODO inline and remove; used only in one place and confusing.
   public Variable getFirstVariableFromLastStatementVariables() {
-    if (lastStatementVariables.size() == 0) throw new IllegalStateException();
+    if (lastStatementVariables.isEmpty()) throw new IllegalStateException();
     return lastStatementVariables.get(0);
   }
 
@@ -983,7 +983,7 @@ public final class Sequence implements WeightedElement {
 
         // Find input variables from their names.
         String[] inVars = new String[0];
-        if (inVarsStr.trim().length() > 0) {
+        if (!inVarsStr.trim().isEmpty()) {
           // One or more input vars.
           inVars = inVarsStr.split("\\s");
         }

--- a/src/main/java/randoop/test/RegressionCaptureVisitor.java
+++ b/src/main/java/randoop/test/RegressionCaptureVisitor.java
@@ -136,7 +136,7 @@ public final class RegressionCaptureVisitor implements TestCheckGenerator {
 
             // If the value is returned from a Date that we created,
             // don't use it as it's just going to have today's date in it.
-            if (s.sequence.getInputs(i).size() > 0) {
+            if (!s.sequence.getInputs(i).isEmpty()) {
               Variable var0 = s.sequence.getInputs(i).get(0);
               if (var0.getType().hasRuntimeClass(java.util.Date.class)) {
                 Statement sk = s.sequence.getCreatingStatement(var0);

--- a/src/main/java/randoop/util/Randomness.java
+++ b/src/main/java/randoop/util/Randomness.java
@@ -50,7 +50,7 @@ public final class Randomness {
   }
 
   public static <T> T randomMember(SimpleList<T> list) {
-    if (list == null || list.size() == 0)
+    if (list == null || list.isEmpty())
       throw new IllegalArgumentException("Expected non-empty list");
     return list.get(nextRandomInt(list.size()));
   }

--- a/src/main/java/randoop/util/StringLineIterator.java
+++ b/src/main/java/randoop/util/StringLineIterator.java
@@ -24,7 +24,7 @@ public class StringLineIterator {
    * @return true if there are more words, false otherwise
    */
   public boolean hasMoreWords() {
-    return this.words.size() > 0;
+    return !this.words.isEmpty();
   }
 
   /**

--- a/src/systemtest/java/randoop/main/RandoopSystemTest.java
+++ b/src/systemtest/java/randoop/main/RandoopSystemTest.java
@@ -677,7 +677,7 @@ public class RandoopSystemTest {
     // definitely cannot do anything useful if no generated test files
     // but not sure that this is the right way to deal with it
     // what if test is meant not to generate anything ?
-    if (testClassSourceFiles.size() == 0) {
+    if (testClassSourceFiles.isEmpty()) {
       for (String line : randoopExitStatus.outputLines) {
         System.err.println(line);
       }

--- a/src/test/java/randoop/generation/TestClassificationTest.java
+++ b/src/test/java/randoop/generation/TestClassificationTest.java
@@ -71,7 +71,7 @@ public class TestClassificationTest {
     List<ExecutableSequence> rTests = gen.getRegressionSequences();
     List<ExecutableSequence> eTests = gen.getErrorTestSequences();
 
-    assertTrue("should have some regression tests", rTests.size() > 0);
+    assertTrue("should have some regression tests", !rTests.isEmpty());
 
     for (ExecutableSequence s : rTests) {
       TestChecks cks = s.getChecks();
@@ -112,7 +112,7 @@ public class TestClassificationTest {
     List<ExecutableSequence> rTests = gen.getRegressionSequences();
     List<ExecutableSequence> eTests = gen.getErrorTestSequences();
 
-    assertTrue("should have some regression tests", rTests.size() > 0);
+    assertTrue("should have some regression tests", !rTests.isEmpty());
 
     for (ExecutableSequence s : rTests) {
       TestChecks cks = s.getChecks();
@@ -126,7 +126,7 @@ public class TestClassificationTest {
       }
     }
 
-    assertTrue("should have some error tests", eTests.size() > 0);
+    assertTrue("should have some error tests", !eTests.isEmpty());
 
     for (ExecutableSequence s : eTests) {
       TestChecks cks = s.getChecks();
@@ -167,7 +167,7 @@ public class TestClassificationTest {
     List<ExecutableSequence> rTests = gen.getRegressionSequences();
     List<ExecutableSequence> eTests = gen.getErrorTestSequences();
 
-    assertTrue("should have some regression tests", rTests.size() > 0);
+    assertTrue("should have some regression tests", !rTests.isEmpty());
 
     for (ExecutableSequence s : rTests) {
       TestChecks cks = s.getChecks();
@@ -211,7 +211,7 @@ public class TestClassificationTest {
     List<ExecutableSequence> rTests = gen.getRegressionSequences();
     List<ExecutableSequence> eTests = gen.getErrorTestSequences();
 
-    assertTrue("should have some regression tests", rTests.size() > 0);
+    assertTrue("should have some regression tests", !rTests.isEmpty());
 
     for (ExecutableSequence s : rTests) {
       TestChecks cks = s.getChecks();
@@ -227,7 +227,7 @@ public class TestClassificationTest {
       }
     }
 
-    assertTrue("should have error tests", eTests.size() > 0);
+    assertTrue("should have error tests", !eTests.isEmpty());
 
     for (ExecutableSequence s : eTests) {
       TestChecks cks = s.getChecks();
@@ -269,7 +269,7 @@ public class TestClassificationTest {
     List<ExecutableSequence> rTests = gen.getRegressionSequences();
     List<ExecutableSequence> eTests = gen.getErrorTestSequences();
 
-    assertTrue("should have some regression tests", rTests.size() > 0);
+    assertTrue("should have some regression tests", !rTests.isEmpty());
 
     for (ExecutableSequence s : rTests) {
       TestChecks cks = s.getChecks();
@@ -287,7 +287,7 @@ public class TestClassificationTest {
       }
     }
 
-    assertTrue("should have error tests", eTests.size() > 0);
+    assertTrue("should have error tests", !eTests.isEmpty());
 
     for (ExecutableSequence s : eTests) {
       TestChecks cks = s.getChecks();

--- a/src/test/java/randoop/generation/TestFilteringTest.java
+++ b/src/test/java/randoop/generation/TestFilteringTest.java
@@ -61,8 +61,8 @@ public class TestFilteringTest {
     List<ExecutableSequence> rTests = gen.getRegressionSequences();
     List<ExecutableSequence> eTests = gen.getErrorTestSequences();
 
-    assertTrue("should have some regression tests", rTests.size() > 0);
-    assertTrue("should have some error tests", eTests.size() > 0);
+    assertTrue("should have some regression tests", !rTests.isEmpty());
+    assertTrue("should have some error tests", !eTests.isEmpty());
   }
 
   /**
@@ -92,8 +92,8 @@ public class TestFilteringTest {
     List<ExecutableSequence> rTests = gen.getRegressionSequences();
     List<ExecutableSequence> eTests = gen.getErrorTestSequences();
 
-    assertTrue("should have no regression tests", rTests.size() == 0);
-    assertTrue("should have no error tests", eTests.size() == 0);
+    assertTrue("should have no regression tests", rTests.isEmpty());
+    assertTrue("should have no error tests", eTests.isEmpty());
   }
 
   /**
@@ -121,8 +121,8 @@ public class TestFilteringTest {
     List<ExecutableSequence> rTests = gen.getRegressionSequences();
     List<ExecutableSequence> eTests = gen.getErrorTestSequences();
 
-    assertTrue("should have some regression tests", rTests.size() > 0);
-    assertTrue("should have no error tests", eTests.size() == 0);
+    assertTrue("should have some regression tests", !rTests.isEmpty());
+    assertTrue("should have no error tests", eTests.isEmpty());
   }
 
   /**
@@ -152,8 +152,8 @@ public class TestFilteringTest {
     List<ExecutableSequence> rTests = gen.getRegressionSequences();
     List<ExecutableSequence> eTests = gen.getErrorTestSequences();
 
-    assertTrue("should have no regression tests, but getting " + rTests.size(), rTests.size() == 0);
-    assertTrue("should have some error tests", eTests.size() > 0);
+    assertTrue("should have no regression tests, but getting " + rTests.size(), rTests.isEmpty());
+    assertTrue("should have some error tests", !eTests.isEmpty());
   }
 
   /**
@@ -183,8 +183,8 @@ public class TestFilteringTest {
     List<ExecutableSequence> rTests = gen.getRegressionSequences();
     List<ExecutableSequence> eTests = gen.getErrorTestSequences();
 
-    assertTrue("should have no regression tests", rTests.size() == 0);
-    assertTrue("should have no error tests", eTests.size() == 0);
+    assertTrue("should have no regression tests", rTests.isEmpty());
+    assertTrue("should have no error tests", eTests.isEmpty());
   }
 
   /**
@@ -213,8 +213,8 @@ public class TestFilteringTest {
     List<ExecutableSequence> rTests = gen.getRegressionSequences();
     List<ExecutableSequence> eTests = gen.getErrorTestSequences();
 
-    assertTrue("should have some regression tests", rTests.size() > 0);
-    assertTrue("should have some error tests", eTests.size() > 0);
+    assertTrue("should have some regression tests", !rTests.isEmpty());
+    assertTrue("should have some error tests", !eTests.isEmpty());
   }
 
   private ForwardGenerator buildGenerator(Class<?> c) {

--- a/src/test/java/randoop/operation/FieldGetterTest.java
+++ b/src/test/java/randoop/operation/FieldGetterTest.java
@@ -205,7 +205,7 @@ public class FieldGetterTest {
     });
     try {
       FieldGet.parse(getterDescr, operationManager);
-      assert ops.size() > 0 : "operations should have element";
+      assert !ops.isEmpty() : "operations should have element";
       ConcreteOperation getter = ops.get(0);
       assertEquals(
           "parse should return object that converts to string",

--- a/src/test/java/randoop/operation/FieldSetterTest.java
+++ b/src/test/java/randoop/operation/FieldSetterTest.java
@@ -227,7 +227,7 @@ public class FieldSetterTest {
     });
     try {
       FieldSet.parse(setterDesc, operationManager);
-      assert ops.size() > 0 : "operations should have element";
+      assert !ops.isEmpty() : "operations should have element";
       ConcreteOperation setter = ops.get(0);
       assertEquals(
           "parse should return object that converts to string",

--- a/src/test/java/randoop/operation/OperationParserTests.java
+++ b/src/test/java/randoop/operation/OperationParserTests.java
@@ -176,6 +176,6 @@ public class OperationParserTests {
     assertTrue(
         stStr + "," + collectedOperation.toParseableString(),
         stStr.equals(collectedOperation.toParseableString()));
-    assertTrue("no generic operations: ", genericOperations.size() == 0);
+    assertTrue("no generic operations: ", genericOperations.isEmpty());
   }
 }

--- a/src/test/java/randoop/reflection/OperationModelTest.java
+++ b/src/test/java/randoop/reflection/OperationModelTest.java
@@ -48,7 +48,7 @@ public class OperationModelTest {
     }
     assert model != null : "model was not initialized";
     assertThat("only expect the LinkedList and Object classes", model.getClasses().size(), is(equalTo(2)));
-    assertTrue("should have nonzero operations set", model.getConcreteOperations().size() > 0);
+    assertTrue("should have nonzero operations set", !model.getConcreteOperations().isEmpty());
 
   }
 
@@ -76,7 +76,7 @@ public class OperationModelTest {
     assert model != null: "model was not initialized";
     assertThat("should have both outer and inner classes, plus Object", model.getClasses().size(), is(equalTo(3)));
 
-    assertTrue("should have nonzero operations set", model.getConcreteOperations().size() > 0);
+    assertTrue("should have nonzero operations set", !model.getConcreteOperations().isEmpty());
 
   }
 }

--- a/src/test/java/randoop/test/ForwardExplorerTests.java
+++ b/src/test/java/randoop/test/ForwardExplorerTests.java
@@ -51,7 +51,7 @@ public class ForwardExplorerTests {
 
     final List<ConcreteOperation> model = getConcreteOperations(classes);
 
-    assertTrue("model not empty", model.size() != 0);
+    assertTrue("model not empty", !model.isEmpty());
     GenInputsAbstract.dontexecute = true; // FIXME make this an instance field?
     ComponentManager mgr = new ComponentManager(SeedSequences.defaultSeeds());
     ForwardGenerator explorer =
@@ -97,7 +97,7 @@ public class ForwardExplorerTests {
     ReflectionExecutor.timeout = 200;
     ComponentManager mgr = new ComponentManager(SeedSequences.defaultSeeds());
     final List<ConcreteOperation> model = getConcreteOperations(classes);
-    assertTrue("model should not be empty", model.size() != 0);
+    assertTrue("model should not be empty", !model.isEmpty());
     GenInputsAbstract.ignore_flaky_tests = true;
     ForwardGenerator exp = new ForwardGenerator(model, new LinkedHashSet<ConcreteOperation>(), Long.MAX_VALUE, 200, 200, mgr, null, null);
     exp.addTestCheckGenerator(createChecker(new LinkedHashSet<ObjectContract>()));
@@ -148,7 +148,7 @@ public class ForwardExplorerTests {
     GenInputsAbstract.ignore_flaky_tests = true;
     ComponentManager mgr = new ComponentManager(SeedSequences.defaultSeeds());
     final List<ConcreteOperation> model = getConcreteOperations(classes);
-    assertTrue("model should not be empty", model.size() != 0);
+    assertTrue("model should not be empty", !model.isEmpty());
     ForwardGenerator exp = new ForwardGenerator(model, new LinkedHashSet<ConcreteOperation>(), Long.MAX_VALUE, 200, 200, mgr, null, null);
     GenInputsAbstract.forbid_null = false;
     exp.addTestCheckGenerator(createChecker(new LinkedHashSet<ObjectContract>()));

--- a/src/test/java/randoop/test/ForwardExplorerTests2.java
+++ b/src/test/java/randoop/test/ForwardExplorerTests2.java
@@ -46,7 +46,7 @@ public class ForwardExplorerTests2  {
 
     //SimpleExplorer exp = new SimpleExplorer(classes, Long.MAX_VALUE, 100);
     List<ConcreteOperation> model = getConcreteOperations(classes);
-    assertTrue("model should not be empty", model.size() != 0);
+    assertTrue("model should not be empty", !model.isEmpty());
     ComponentManager mgr = new ComponentManager(SeedSequences.defaultSeeds());
     ForwardGenerator exp = new ForwardGenerator(model, new LinkedHashSet<ConcreteOperation>(), Long.MAX_VALUE, 100, 100, mgr, null, null);
     exp.addTestCheckGenerator(createChecker(new LinkedHashSet<ObjectContract>()));

--- a/src/test/java/randoop/test/SequenceTests.java
+++ b/src/test/java/randoop/test/SequenceTests.java
@@ -136,7 +136,7 @@ public class SequenceTests {
       throw new IllegalArgumentException(
           "Malformed test record (missing \"EXPECTED_CODE\" record): " + lines.toString());
     }
-    if (sequenceLines.size() == 0) {
+    if (sequenceLines.isEmpty()) {
       throw new IllegalArgumentException("Empty sequence found.");
     }
 
@@ -147,7 +147,7 @@ public class SequenceTests {
       currIdx++;
     }
 
-    if (expectedCode.size() == 0) {
+    if (expectedCode.isEmpty()) {
       throw new IllegalArgumentException("Expected code is empty.");
     }
 

--- a/src/test/java/randoop/test/issta2006/FibHeap.java
+++ b/src/test/java/randoop/test/issta2006/FibHeap.java
@@ -220,7 +220,7 @@ public class FibHeap {
   public static java.util.Random rand = new java.util.Random(0);
 
   public void deleteRandomNode() {
-    if (cachedNodes.size() == 0) return;
+    if (cachedNodes.isEmpty()) return;
     delete(cachedNodes.get(rand.nextInt(cachedNodes.size())));
   }
 

--- a/src/test/java/randoop/test/symexamples/Collections.java
+++ b/src/test/java/randoop/test/symexamples/Collections.java
@@ -3407,7 +3407,7 @@ public class Collections {
 
     @Override
     public boolean equals(Object o) {
-      return (o instanceof Map) && ((Map) o).size() == 0;
+      return (o instanceof Map) && ((Map) o).isEmpty();
     }
 
     @Override

--- a/src/testinput/java/java2/util2/Collections.java
+++ b/src/testinput/java/java2/util2/Collections.java
@@ -2382,7 +2382,7 @@ public class Collections {
     }
 
     public boolean equals(Object o) {
-      return (o instanceof Map) && ((Map) o).size() == 0;
+      return (o instanceof Map) && ((Map) o).isEmpty();
     }
 
     public int hashCode() {

--- a/src/testinput/java/java2/util2/TreeSet.java
+++ b/src/testinput/java/java2/util2/TreeSet.java
@@ -238,7 +238,7 @@ public class TreeSet extends AbstractSet implements SortedSet, Cloneable, java.i
    */
   public boolean addAll(Collection c) {
     // Use linear-time version if applicable
-    if (m.size() == 0 && c.size() > 0 && c instanceof SortedSet && m instanceof TreeMap) {
+    if (m.isEmpty() && !c.isEmpty() && c instanceof SortedSet && m instanceof TreeMap) {
       SortedSet set = (SortedSet) c;
       TreeMap map = (TreeMap) m;
       Comparator cc = set.comparator();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
Ayman Abdelghany.