### PR TITLE
Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/src/test/java/randoop/test/bh/MathVector.java
+++ b/src/test/java/randoop/test/bh/MathVector.java
@@ -209,7 +209,7 @@ public class MathVector implements Cloneable {
    **/
   @Override
   public String toString() {
-    StringBuffer s = new StringBuffer();
+    StringBuilder s = new StringBuilder();
     for (int i = 0; i < NDIM; i++) {
       s.append(data[i] + " ");
     }

--- a/src/test/java/randoop/test/symexamples/AbstractMap.java
+++ b/src/test/java/randoop/test/symexamples/AbstractMap.java
@@ -253,7 +253,7 @@ public abstract class AbstractMap implements Map {
 
   @Override
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append("{");
     Iterator i = entrySet().iterator();
     boolean hasNext = i.hasNext();

--- a/src/testinput/java/java2/util2/AbstractCollection.java
+++ b/src/testinput/java/java2/util2/AbstractCollection.java
@@ -430,7 +430,7 @@ public abstract class AbstractCollection implements Collection {
    * @return a string representation of this collection.
    */
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append("[");
 
     Iterator i = iterator();

--- a/src/testinput/java/java2/util2/AbstractMap.java
+++ b/src/testinput/java/java2/util2/AbstractMap.java
@@ -555,12 +555,12 @@ public abstract class AbstractMap implements Map {
    * the string representation of each <tt>map.entry</tt> in turn.  After
    * appending each entry except the last, the string <tt>", "</tt> is
    * appended.  Finally a right brace is appended.  A string is obtained
-   * from the stringbuffer, and returned.
+   * from the StringBuilder, and returned.
    *
    * @return a String representation of this map.
    */
   public String toString() {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append("{");
 
     Iterator i = entrySet().iterator();

--- a/src/testinput/java/java2/util2/BitSet.java
+++ b/src/testinput/java/java2/util2/BitSet.java
@@ -941,7 +941,7 @@ public class BitSet implements Cloneable, java.io.Serializable {
    */
   public String toString() {
     int numBits = unitsInUse << ADDRESS_BITS_PER_UNIT;
-    StringBuffer buffer = new StringBuffer(8 * numBits + 2);
+    StringBuilder buffer = new StringBuilder(8 * numBits + 2);
     String separator = "";
     buffer.append('{');
 

--- a/src/testinput/java/java2/util2/Hashtable.java
+++ b/src/testinput/java/java2/util2/Hashtable.java
@@ -514,7 +514,7 @@ public class Hashtable extends Dictionary implements Map, Cloneable, java.io.Ser
    */
   public synchronized String toString() {
     int max = size() - 1;
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     Iterator it = entrySet().iterator();
 
     buf.append("{");

--- a/src/testinput/java/ps1/RatPoly.java
+++ b/src/testinput/java/ps1/RatPoly.java
@@ -168,7 +168,7 @@ public class RatPoly {
       return "0";
     }
 
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     boolean isNegative;
     RatNum coeff = null;
     for (int i = 0, size = terms.size(); i < size; i++) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
Ayman Abdelghany.