### PR TITLE
Remove redundant, compile-blocking @param from doc

### DIFF
--- a/src/main/java/randoop/output/RandoopOutputException.java
+++ b/src/main/java/randoop/output/RandoopOutputException.java
@@ -29,7 +29,6 @@ public class RandoopOutputException extends Throwable {
   /**
    * Creates a {@link RandoopOutputException} with the cause.
    *
-   * @param message the error message
    * @param cause the exception for the error
    */
   public RandoopOutputException(IOException cause) {


### PR DESCRIPTION
The redundant `@param message the error message` in the method doc of constructor `randoop.output.RandoopOutputException(IOException cause)` is regarded as an error by `javadoc`.

It blocks compiling randoop from a clean clone.