### PR TITLE
parser fixes

### DIFF
--- a/src/main/java/randoop/output/JUnitCreator.java
+++ b/src/main/java/randoop/output/JUnitCreator.java
@@ -46,7 +46,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import randoop.BugInRandoopException;
 import randoop.Globals;
+import randoop.main.GenInputsAbstract;
 import randoop.sequence.ExecutableSequence;
 
 /** Creates Java source as {@code String} for a suite of JUnit4 tests. */
@@ -294,7 +296,9 @@ public class JUnitCreator {
       System.out.println(
           "Parse error while creating test method " + className + "." + methodName + " for block ");
       System.out.println(sequenceBlockString);
-      return null;
+      if (GenInputsAbstract.debug_checks) {
+        throw new BugInRandoopException("Parse error while creating test method", e);
+      }
     } catch (TokenMgrError e) {
       System.out.println(
           "Lexical error while creating test method " + className + "." + methodName);

--- a/src/main/java/randoop/output/JUnitCreator.java
+++ b/src/main/java/randoop/output/JUnitCreator.java
@@ -48,7 +48,6 @@ import java.util.Map;
 import java.util.Set;
 import randoop.BugInRandoopException;
 import randoop.Globals;
-import randoop.main.GenInputsAbstract;
 import randoop.sequence.ExecutableSequence;
 
 /** Creates Java source as {@code String} for a suite of JUnit4 tests. */
@@ -296,9 +295,7 @@ public class JUnitCreator {
       System.out.println(
           "Parse error while creating test method " + className + "." + methodName + " for block ");
       System.out.println(sequenceBlockString);
-      if (GenInputsAbstract.debug_checks) {
-        throw new BugInRandoopException("Parse error while creating test method", e);
-      }
+      throw new BugInRandoopException("Parse error while creating test method", e);
     } catch (TokenMgrError e) {
       System.out.println(
           "Lexical error while creating test method " + className + "." + methodName);

--- a/src/main/java/randoop/test/ExpectedExceptionCheck.java
+++ b/src/main/java/randoop/test/ExpectedExceptionCheck.java
@@ -68,12 +68,13 @@ public class ExpectedExceptionCheck extends ExceptionCheck {
 
   /**
    * Ensures that the fail message built from an exception message is formatted propertly for use in
-   * an assertion by removing newlines.
+   * an assertion by removing newlines. Also, escapes embedded quotes; i.e. " => \".
    *
    * @param message the message to convert
    * @return the message with newlines removed
    */
   private static String fixMessage(String message) {
+    message = message.replaceAll("\"", "\\\\\"");
     return message.replaceAll("[\\r\\n]+", ".");
   }
 }


### PR DESCRIPTION
terminate on parse error if debug-checks is set.  my limited testing showed no significant performance cost for --debug-checks.  We could use for in-house testing and default behavior would be unchanged.

correct parse error with embedded quotes (")