### PR TITLE
Fix randoop error on encountering an unparameterized type that extend…

### DIFF
--- a/src/main/java/randoop/reflection/OperationExtractor.java
+++ b/src/main/java/randoop/reflection/OperationExtractor.java
@@ -157,6 +157,11 @@ public class OperationExtractor extends DefaultClassVisitor {
    */
   // TODO: poor name
   private void checkSubTypes(TypedClassOperation operation) {
+
+    if (operation.getDeclaringType().isGeneric() && !classType.hasWildcard()) {
+      if (classType.isSubtypeOf(operation.getDeclaringType().getRawtype()))
+        return;
+    }
     if (!classType.isSubtypeOf(operation.getDeclaringType())) {
       throw new BugInRandoopException(
           String.format("Incompatible receiver type %s for operation %s", classType, operation));


### PR DESCRIPTION
I have an older Java library that extends java.util.ArrayList<E> resulting in a non-generic type. Randoop bails out on encountering the operation java.util.ArrayList<E>.add(E) complaining that the receiver is not a subtype of java.util.ArrayList<E>