### PR TITLE
new flaky-test-behavior option (supersedes ignore-flaky-tests)

### DIFF
--- a/src/docs/CHANGES.txt
+++ b/src/docs/CHANGES.txt
@@ -45,7 +45,11 @@ Added the --print-file-system-state command-line argument (default = false).
 When set to true, any generated tests containing compilation errors
 will be copied to standard out.
 
-Fixes a problem in progress reporting where the wrong count was being used for
+Renamed the --ignore-flaky-tests option to --flaky-test-behavior.  This is now
+an enum: HALT - Halt and give a diagnostic message (default); DISCARD: Discard
+the flaky test; and OUTPUT: Output the flaky test.
+
+Fixed a problem in progress reporting where the wrong count was being used for
 error-revealing sequences.
 
 Added the --deterministic command-line argument (default = false).  When

--- a/src/docs/manual/index.html
+++ b/src/docs/manual/index.html
@@ -833,13 +833,19 @@ Randoop about your application, and that is how we recommend using Randoop.
  a member of the same package as the generated tests. [default false]
             <li id="option:silently-ignore-bad-class-names"><b>--silently-ignore-bad-class-names=</b><i>boolean</i>.
              Ignore class names specified by user that cannot be found [default false]
-            <li id="option:ignore-flaky-tests"><b>--ignore-flaky-tests=</b><i>boolean</i>.
-             If false, Randoop halts and gives diagnostics about flaky tests -- tests that behave
- differently on different executions. If true, Randoop ignores them and does not output them.
+            <li id="option:flaky-test-behavior"><b>--flaky-test-behavior=</b><i>enum</i>.
+             How to respond to non-determinism in test execution. Flaky tests are tests that behave
+ differently on different executions.
 
- <p>Use of this option is a last resort. Flaky tests are usually due to calling Randoop on
- side-effecting or nondeterministic methods, and a better solution is not to call Randoop on
- such methods; see the Randoop manual. [default false]
+ <p>Setting this option to DISCARD or OUTPUT should be considered a last resort. Flaky tests are
+ usually due to calling Randoop on side-effecting or nondeterministic methods, and a better
+ solution is not to call Randoop on such methods; see the Randoop manual. See: <code>FlakyTestAction</code>. [default HALT]
+<ul>
+  <li><b>HALT</b> A flaky test should cause Randoop to halt and give a diagnostic message.
+  <li><b>DISCARD</b> A flaky test should be discarded.
+  <li><b>OUTPUT</b> A flaky test should be ignored and output anyway.
+</ul>
+
       </ul>
   <li id="optiongroup:Which-tests-to-output">Which tests to output
       <ul>

--- a/src/docs/manual/index.html
+++ b/src/docs/manual/index.html
@@ -834,16 +834,17 @@ Randoop about your application, and that is how we recommend using Randoop.
             <li id="option:silently-ignore-bad-class-names"><b>--silently-ignore-bad-class-names=</b><i>boolean</i>.
              Ignore class names specified by user that cannot be found [default false]
             <li id="option:flaky-test-behavior"><b>--flaky-test-behavior=</b><i>enum</i>.
-             How to respond to non-determinism in test execution. Flaky tests are tests that behave
- differently on different executions.
+             What to do if Randoop generates a flaky test. A flaky test is one that behaves differently on
+ different executions.
 
- <p>Setting this option to DISCARD or OUTPUT should be considered a last resort. Flaky tests are
- usually due to calling Randoop on side-effecting or nondeterministic methods, and a better
- solution is not to call Randoop on such methods; see the Randoop manual. See: <code>FlakyTestAction</code>. [default HALT]
+ <p>Setting this option to <code>DISCARD</code> or <code>OUTPUT</code> should be considered a last resort.
+ Flaky tests are usually due to calling Randoop on side-effecting or nondeterministic methods,
+ and a better solution is not to call Randoop on such methods; see the discussion of
+ nondeterminism in the Randoop manual. [default HALT]
 <ul>
-  <li><b>HALT</b> A flaky test should cause Randoop to halt and give a diagnostic message.
-  <li><b>DISCARD</b> A flaky test should be discarded.
-  <li><b>OUTPUT</b> A flaky test should be ignored and output anyway.
+  <li><b>HALT</b> Randoop halts with a diagnostic message.
+  <li><b>DISCARD</b> Discard the flaky test.
+  <li><b>OUTPUT</b> Output the flaky test; the resulting test suite may fail when it is run.
 </ul>
 
       </ul>

--- a/src/main/java/randoop/main/GenInputsAbstract.java
+++ b/src/main/java/randoop/main/GenInputsAbstract.java
@@ -140,15 +140,31 @@ public abstract class GenInputsAbstract extends CommandHandler {
   public static boolean fail_on_generation_error = false;
 
   /**
-   * If false, Randoop halts and gives diagnostics about flaky tests -- tests that behave
-   * differently on different executions. If true, Randoop ignores them and does not output them.
+   * The possible values of the flaky_test_behavior command-line argument.
    *
-   * <p>Use of this option is a last resort. Flaky tests are usually due to calling Randoop on
-   * side-effecting or nondeterministic methods, and a better solution is not to call Randoop on
-   * such methods; see the Randoop manual.
+   * @see #flaky_test_behavior
    */
-  @Option("Whether to ignore non-determinism in test execution")
-  public static boolean ignore_flaky_tests = false;
+  public enum FlakyTestAction {
+    /** A flaky test should cause Randoop to halt and give a diagnostic message. */
+    HALT,
+    /** A flaky test should be discarded. */
+    DISCARD,
+    /** A flaky test should be ignored and output anyway. */
+    OUTPUT
+  }
+
+  /**
+   * How to respond to non-determinism in test execution. Flaky tests are tests that behave
+   * differently on different executions.
+   *
+   * <p>Setting this option to DISCARD or OUTPUT should be considered a last resort. Flaky tests are
+   * usually due to calling Randoop on side-effecting or nondeterministic methods, and a better
+   * solution is not to call Randoop on such methods; see the Randoop manual.
+   *
+   * @see FlakyTestAction
+   */
+  @Option("How to respond to non-determinism in test execution")
+  public static FlakyTestAction flaky_test_behavior = FlakyTestAction.HALT;
 
   /**
    * Whether to output error-revealing tests. Disables all output when used with {@code

--- a/src/main/java/randoop/main/GenInputsAbstract.java
+++ b/src/main/java/randoop/main/GenInputsAbstract.java
@@ -140,30 +140,29 @@ public abstract class GenInputsAbstract extends CommandHandler {
   public static boolean fail_on_generation_error = false;
 
   /**
-   * The possible values of the flaky_test_behavior command-line argument.
+   * Possible behaviors if Randoop generates a flaky test.
    *
    * @see #flaky_test_behavior
    */
   public enum FlakyTestAction {
-    /** A flaky test should cause Randoop to halt and give a diagnostic message. */
+    /** Randoop halts with a diagnostic message. */
     HALT,
-    /** A flaky test should be discarded. */
+    /** Discard the flaky test. */
     DISCARD,
-    /** A flaky test should be ignored and output anyway. */
+    /** Output the flaky test; the resulting test suite may fail when it is run. */
     OUTPUT
   }
 
   /**
-   * How to respond to non-determinism in test execution. Flaky tests are tests that behave
-   * differently on different executions.
+   * What to do if Randoop generates a flaky test. A flaky test is one that behaves differently on
+   * different executions.
    *
-   * <p>Setting this option to DISCARD or OUTPUT should be considered a last resort. Flaky tests are
-   * usually due to calling Randoop on side-effecting or nondeterministic methods, and a better
-   * solution is not to call Randoop on such methods; see the Randoop manual.
-   *
-   * @see FlakyTestAction
+   * <p>Setting this option to {@code DISCARD} or {@code OUTPUT} should be considered a last resort.
+   * Flaky tests are usually due to calling Randoop on side-effecting or nondeterministic methods,
+   * and a better solution is not to call Randoop on such methods; see the discussion of
+   * nondeterminism in the Randoop manual.
    */
-  @Option("How to respond to non-determinism in test execution")
+  @Option("What to do if a flaky test is generated")
   public static FlakyTestAction flaky_test_behavior = FlakyTestAction.HALT;
 
   /**

--- a/src/main/java/randoop/main/GenTests.java
+++ b/src/main/java/randoop/main/GenTests.java
@@ -895,7 +895,9 @@ public class GenTests extends GenInputsAbstract {
 
     // Start with checking for invalid exceptions.
     TestCheckGenerator testGen =
-        new ValidityCheckingGenerator(IS_INVALID, !GenInputsAbstract.ignore_flaky_tests);
+        new ValidityCheckingGenerator(
+            IS_INVALID,
+            GenInputsAbstract.flaky_test_behavior == FlakyTestAction.HALT ? true : false);
 
     // Extend with contract checker.
     ContractCheckingGenerator contractVisitor = new ContractCheckingGenerator(contracts, IS_ERROR);

--- a/src/main/java/randoop/main/GenTests.java
+++ b/src/main/java/randoop/main/GenTests.java
@@ -896,8 +896,7 @@ public class GenTests extends GenInputsAbstract {
     // Start with checking for invalid exceptions.
     TestCheckGenerator testGen =
         new ValidityCheckingGenerator(
-            IS_INVALID,
-            GenInputsAbstract.flaky_test_behavior == FlakyTestAction.HALT ? true : false);
+            IS_INVALID, GenInputsAbstract.flaky_test_behavior == FlakyTestAction.HALT);
 
     // Extend with contract checker.
     ContractCheckingGenerator contractVisitor = new ContractCheckingGenerator(contracts, IS_ERROR);

--- a/src/main/java/randoop/output/FailingTestFilter.java
+++ b/src/main/java/randoop/output/FailingTestFilter.java
@@ -86,8 +86,7 @@ public class FailingTestFilter implements CodeWriter {
     String qualifiedClassname = packageName == null ? classname : packageName + "." + classname;
 
     int pass = 0; // Used to create unique working directory name.
-    boolean passing =
-        GenInputsAbstract.flaky_test_behavior == FlakyTestAction.OUTPUT ? true : false;
+    boolean passing = GenInputsAbstract.flaky_test_behavior == FlakyTestAction.OUTPUT;
 
     while (!passing) {
       Path workingDirectory = createWorkingDirectory(classname, pass);
@@ -292,18 +291,18 @@ public class FailingTestFilter implements CodeWriter {
 
       if (GenInputsAbstract.flaky_test_behavior == FlakyTestAction.HALT) {
         String message =
-            "A test code assertion failed during flaky-test filtering. Most likely, you ran Randoop on a program with nondeterministic behavior.  See section #nondeterminism-in-program-under-test for ways to handle this.";
-        message =
-            message.concat(
-                String.format(
-                    "%nClass: %s, Method: %s, Line number: %d, Source line:%n%s%n",
-                    classname, methodName, lineNumber, javaCodeLines[lineNumber - 1]));
+            "A test code assertion failed during flaky-test filtering. Most likely,%n"
+                + "you ran Randoop on a program with nondeterministic behavior. See the%n"
+                + "Randoop manual's discussion of nondeterminism for ways to handle this.%n"
+                + String.format(
+                    "Class: %s, Method: %s, Line number: %d, Source line:%n%s%n",
+                    classname, methodName, lineNumber, javaCodeLines[lineNumber - 1]);
         if (GenInputsAbstract.print_file_system_state) {
           message = message.concat(String.format("Source file:%n%s%n", javaCode));
         } else {
           message =
-              message.concat(
-                  "(You may use the --print-file-system-state option to dump a copy of the source file.)\n");
+              String.format(
+                  "(You may use the --print-file-system-state option to dump a copy of the source file.)%n");
         }
         throw new RandoopUsageError(message);
       }

--- a/src/main/java/randoop/output/FailingTestFilter.java
+++ b/src/main/java/randoop/output/FailingTestFilter.java
@@ -2,6 +2,7 @@ package randoop.output;
 
 import static randoop.execution.RunCommand.CommandException;
 import static randoop.execution.RunCommand.Status;
+import static randoop.main.GenInputsAbstract.FlakyTestAction;
 import static randoop.reflection.SignatureParser.DOT_DELIMITED_IDS;
 import static randoop.reflection.SignatureParser.ID_STRING;
 
@@ -85,7 +86,8 @@ public class FailingTestFilter implements CodeWriter {
     String qualifiedClassname = packageName == null ? classname : packageName + "." + classname;
 
     int pass = 0; // Used to create unique working directory name.
-    boolean passing = false;
+    boolean passing =
+        GenInputsAbstract.flaky_test_behavior == FlakyTestAction.OUTPUT ? true : false;
 
     while (!passing) {
       Path workingDirectory = createWorkingDirectory(classname, pass);
@@ -288,6 +290,24 @@ public class FailingTestFilter implements CodeWriter {
                 + failureLineMatch.line);
       }
 
+      if (GenInputsAbstract.flaky_test_behavior == FlakyTestAction.HALT) {
+        String message =
+            "A test code assertion failed during flaky-test filtering. Most likely, you ran Randoop on a program with nondeterministic behavior.  See section #nondeterminism-in-program-under-test for ways to handle this.";
+        message =
+            message.concat(
+                String.format(
+                    "%nClass: %s, Method: %s, Line number: %d, Source line:%n%s%n",
+                    classname, methodName, lineNumber, javaCodeLines[lineNumber - 1]));
+        if (GenInputsAbstract.print_file_system_state) {
+          message = message.concat(String.format("Source file:%n%s%n", javaCode));
+        } else {
+          message =
+              message.concat(
+                  "(You may use the --print-file-system-state option to dump a copy of the source file.)\n");
+        }
+        throw new RandoopUsageError(message);
+      }
+
       javaCodeLines[lineNumber - 1] = flakyLineReplacement(javaCodeLines[lineNumber - 1]);
     }
 
@@ -302,6 +322,7 @@ public class FailingTestFilter implements CodeWriter {
    * @param status the result of running JUnit
    * @param qualifiedClassname the name of the JUnit class, used only for debugging output
    * @param javaCode the JUnit class source code, used only for debugging output
+   * @return the number of JUnit failures
    */
   private int numJunitFailures(
       Iterator<String> lineIterator, Status status, String qualifiedClassname, String javaCode) {

--- a/src/systemtest/java/randoop/main/RandoopSystemTest.java
+++ b/src/systemtest/java/randoop/main/RandoopSystemTest.java
@@ -1292,7 +1292,7 @@ public class RandoopSystemTest {
     //
     options.setOption("output_limit", "1000");
     options.setOption("generated_limit", "3000");
-    options.setFlag("ignore-flaky-tests");
+    options.setOption("flaky-test-behavior", "OUTPUT");
     options.setOption("operation-history-log", "-");
     options.setFlag("usethreads");
     options.unsetFlag("deterministic");
@@ -1462,7 +1462,7 @@ public class RandoopSystemTest {
 
     options.setOption("output_limit", "4");
     options.setOption("generated_limit", "10");
-    options.setFlag("ignore-flaky-tests");
+    options.setOption("flaky-test-behavior", "OUTPUT");
 
     CoverageChecker coverageChecker =
         new CoverageChecker(


### PR DESCRIPTION
Unsure about the error message output in FailingTestFilter.  You suggested "See section #nondeterminism-inprogram-under-test ...".  Not sure if that was literal or implied some sort of href to the manual.