### PR TITLE
Replace calls to instance methods of java.util.Random

### DIFF
--- a/agent/replacecall/src/main/java/randoop/mock/java/util/MockRandom.java
+++ b/agent/replacecall/src/main/java/randoop/mock/java/util/MockRandom.java
@@ -1,0 +1,84 @@
+package randoop.mock.java.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+/**
+ * This class is intended to define replacements to calls to java.util.Random's next[Type] method.
+ * For example, nextInt(), nextDouble, nextFloat(), and nextLong(). Each instance of Random() is
+ * mapped to its own instance of Random(0). This will allow programs that make use of Random() to
+ * behave deterministically in this regard.
+ */
+public class MockRandom {
+  // Map from each instance of Random() in the client's code to a unique instance of Random(0).
+  private static final Map<Random, Random> delegateMap = new HashMap<Random, Random>();
+
+  /** Instances of mock classes should not be created. */
+  private MockRandom() {
+    throw new Error("Do not instantiate");
+  }
+
+  /**
+   * Returns the instance of Random(0) associated with the parameter random. If none exists in the
+   * map, a new instance of Random(0) is created, added to the map and returned.
+   *
+   * @param random instance to map from.
+   * @return instance of Random(0) mapped from random.
+   */
+  private static Random getDelegateForInstance(Random random) {
+    Random delegate = delegateMap.get(random);
+    if (delegate == null) {
+      delegate = new Random(0);
+      delegateMap.put(random, delegate);
+    }
+    return delegate;
+  }
+
+  public static int nextInt(Random random) {
+    return getDelegateForInstance(random).nextInt();
+  }
+
+  public static int nextInt(Random random, int bound) {
+    return getDelegateForInstance(random).nextInt(bound);
+  }
+
+  public static double nextDouble(Random random) {
+    return getDelegateForInstance(random).nextDouble();
+  }
+
+  public static float nextFloat(Random random) {
+    return getDelegateForInstance(random).nextFloat();
+  }
+
+  public static long nextLong(Random random) {
+    return getDelegateForInstance(random).nextLong();
+  }
+
+  public static boolean nextBoolean(Random random) {
+    return getDelegateForInstance(random).nextBoolean();
+  }
+
+  public static double nextGaussian(Random random) {
+    return getDelegateForInstance(random).nextGaussian();
+  }
+
+  public static void nextBytes(Random random, byte[] bytes) {
+    getDelegateForInstance(random).nextBytes(bytes);
+  }
+
+  public static void setSeed(Random random, long seed) {
+    getDelegateForInstance(random).setSeed(seed);
+  }
+
+  // Used to replace calls to the constructor Random().
+  // These methods are currently not used as constructor replacements are not yet supported.
+  /*
+  public static java.util.Random randomWithSeedZero() {
+      return new java.util.Random(0);
+  }
+
+  public static java.util.Random randomWithSeedZero(java.util.Random random) {
+      return new java.util.Random(0);
+  }*/
+}

--- a/agent/replacecall/src/main/java/randoop/mock/java/util/MockRandom.java
+++ b/agent/replacecall/src/main/java/randoop/mock/java/util/MockRandom.java
@@ -5,13 +5,18 @@ import java.util.Map;
 import java.util.Random;
 
 /**
- * This class is intended to define replacements to calls to java.util.Random's next[Type] method.
- * For example, nextInt(), nextDouble, nextFloat(), and nextLong(). Each instance of Random() is
- * mapped to its own instance of Random(0). This will allow programs that make use of Random() to
- * behave deterministically in this regard.
+ * This class defines replacements for calls to java.util.Random's {@code next*} methods, such as
+ * nextInt() and nextDouble().
+ *
+ * <p>The replacements don't use the provided receiver, but a deterministically-created one
+ * (instantiated as {@code Random(0)}) instead. This makes calls to {@code next*} methods behave
+ * deterministically.
  */
 public class MockRandom {
-  // Map from each instance of Random() in the client's code to a unique instance of Random(0).
+  /**
+   * Map from each instance of Random() in the client's code to a unique instance of Random that was
+   * deterministically created as Random(0)..
+   */
   private static final Map<Random, Random> delegateMap = new HashMap<Random, Random>();
 
   /** Instances of mock classes should not be created. */
@@ -20,13 +25,13 @@ public class MockRandom {
   }
 
   /**
-   * Returns the instance of Random(0) associated with the parameter random. If none exists in the
-   * map, a new instance of Random(0) is created, added to the map and returned.
+   * Returns the instance of Random(0) associated with the parameter {@code random}. If none exists
+   * in the map, a new instance of Random(0) is created, added to the map and returned.
    *
    * @param random instance to map from.
    * @return instance of Random(0) mapped from random.
    */
-  private static Random getDelegateForInstance(Random random) {
+  private static Random getDelegate(Random random) {
     Random delegate = delegateMap.get(random);
     if (delegate == null) {
       delegate = new Random(0);
@@ -36,43 +41,45 @@ public class MockRandom {
   }
 
   public static int nextInt(Random random) {
-    return getDelegateForInstance(random).nextInt();
+    return getDelegate(random).nextInt();
   }
 
   public static int nextInt(Random random, int bound) {
-    return getDelegateForInstance(random).nextInt(bound);
+    return getDelegate(random).nextInt(bound);
   }
 
   public static double nextDouble(Random random) {
-    return getDelegateForInstance(random).nextDouble();
+    return getDelegate(random).nextDouble();
   }
 
   public static float nextFloat(Random random) {
-    return getDelegateForInstance(random).nextFloat();
+    return getDelegate(random).nextFloat();
   }
 
   public static long nextLong(Random random) {
-    return getDelegateForInstance(random).nextLong();
+    return getDelegate(random).nextLong();
   }
 
   public static boolean nextBoolean(Random random) {
-    return getDelegateForInstance(random).nextBoolean();
+    return getDelegate(random).nextBoolean();
   }
 
   public static double nextGaussian(Random random) {
-    return getDelegateForInstance(random).nextGaussian();
+    return getDelegate(random).nextGaussian();
   }
 
   public static void nextBytes(Random random, byte[] bytes) {
-    getDelegateForInstance(random).nextBytes(bytes);
+    getDelegate(random).nextBytes(bytes);
   }
 
   public static void setSeed(Random random, long seed) {
-    getDelegateForInstance(random).setSeed(seed);
+    getDelegate(random).setSeed(seed);
   }
 
   // Used to replace calls to the constructor Random().
   // These methods are currently not used as constructor replacements are not yet supported.
+  // Once constructor replacements are supported, the delegates and replacements that use them
+  // are no longer necessary.
   /*
   public static java.util.Random randomWithSeedZero() {
       return new java.util.Random(0);

--- a/agent/replacecall/src/main/resources/default-replacements.txt
+++ b/agent/replacecall/src/main/resources/default-replacements.txt
@@ -1,5 +1,4 @@
 // Default replacement file
-//
 
 // Apply default mock for System.exit that throws randoop.SystemExitCalledError.
 java.lang randoop.mock.java.lang
@@ -7,3 +6,11 @@ java.lang randoop.mock.java.lang
 // Apply mocks for AWT/Swing; see randoop/agent/replacecall/src/main/java/randoop/mock/README
 java.awt randoop.mock.java.awt
 javax.swing randoop.mock.javax.swing
+
+// Currently, the replacecalls agent cannot replace constructors.
+// This can be reinstated, and the replacements for all the methods of
+// Random removed, when replacecalls can handle constructors.
+// java.util.Random.<init>() randoop.mock.java.util.RandomReplace.randomWithSeedZero()
+
+// Replacements to instance method calls of java.util.Random.
+java.util.Random randoop.mock.java.util.MockRandom

--- a/agent/replacecall/src/main/resources/default-replacements.txt
+++ b/agent/replacecall/src/main/resources/default-replacements.txt
@@ -7,10 +7,9 @@ java.lang randoop.mock.java.lang
 java.awt randoop.mock.java.awt
 javax.swing randoop.mock.javax.swing
 
+// Replacements to instance method calls of java.util.Random.
+java.util.Random randoop.mock.java.util.MockRandom
 // Currently, the replacecalls agent cannot replace constructors.
 // This can be reinstated, and the replacements for all the methods of
 // Random removed, when replacecalls can handle constructors.
 // java.util.Random.<init>() randoop.mock.java.util.RandomReplace.randomWithSeedZero()
-
-// Replacements to instance method calls of java.util.Random.
-java.util.Random randoop.mock.java.util.MockRandom

--- a/src/docs/manual/index.html
+++ b/src/docs/manual/index.html
@@ -44,7 +44,10 @@ The Randoop homepage is
       <li><a href="#replacecall">Avoiding calls to specific methods</a>
         <ul>
           <li><a href="#replacecall-load-exclusions">Replacement exclusions</a></li>
-          <li><a href="#replacecall-replacement-definition">Defining replacements</a></li>
+          <li><a href="#replacecall-replacement-definition">Defining replacements</a>
+            <ul>
+              <li><a href="#replacecall-replacement-implementation">Implementing replacement classes</a></li>
+            </ul></li>
         </ul></li>
       <li><a href="#specifying-behavior">Specifying expected code behavior (pre- and post-conditions)</a>
         <ul>
@@ -730,7 +733,7 @@ Here is how Randoop attempts to generate a test:
 </ul>
 
 <p>
-Furthermore, see the <a href="#optiongroup:Threading">ommand-line options
+Furthermore, see the <a href="#optiongroup:Threading">command-line options
 for threading</a> for additional per-test time limits.
 </p>
 
@@ -1416,27 +1419,23 @@ Keep the following in mind when defining replacements:
     Only methods may be replaced. <!-- TODO: does this mean not constructors? -->
   </li>
   <li>
-    If you define a replocement for a method that returns a value,
+    If you define a replacement for a method that returns a value,
     it can change the behavior of client code.
   </li>
 </ul>
 
 
 <h4 id="replacecall-replacement-implementation">Implementing replacement classes</h4>
-<p>
-  In some cases, it might be desirable to replace an instance method call of an object
-  with an instance method call of a different object. It is typically desirable to use
-  a map to associate instances of the original receiver to instances that will be used
-  to replace the call. As an example, the default replacement to the class <code>java.util.Random</code>
-  maps each instance of <code>java.util.Random()</code> to a different instance of
-  <code>java.util.Random(0)</code>. The calls to instance methods such as <code>nextInt()</code>,
-  <code>nextFloat()</code>, and <code>nextDouble()</code>, are delegated to instances of <code>java.util.Random</code>
-  that are seeded with the value of zero.
 
-  This technique of mapping instances to different instances can also be useful in cases
-  where it is desirable to have different types between the original receiver and the object
-  replacing the original receiver.
+<p>
+Sometimes, a replacement for an instance method needs to use a different
+object than the receiver (it might have the same or a different type than
+the receiver).  In this case, your replacement class should maintain a map
+from instances of the original receiver to instances that will be used in
+the replacement.  An example appears in {@code
+randoop.mock.java.util.MockRandom}.
 </p>
+
 
 <h2 id="specifying-behavior">Specifying expected code behavior (pre- and post-conditions)</h2>
 

--- a/src/docs/manual/index.html
+++ b/src/docs/manual/index.html
@@ -1422,6 +1422,22 @@ Keep the following in mind when defining replacements:
 </ul>
 
 
+<h4 id="replacecall-replacement-implementation">Implementing replacement classes</h4>
+<p>
+  In some cases, it might be desirable to replace an instance method call of an object
+  with an instance method call of a different object. It is typically desirable to use
+  a map to associate instances of the original receiver to instances that will be used
+  to replace the call. As an example, the default replacement to the class <code>java.util.Random</code>
+  maps each instance of <code>java.util.Random()</code> to a different instance of
+  <code>java.util.Random(0)</code>. The calls to instance methods such as <code>nextInt()</code>,
+  <code>nextFloat()</code>, and <code>nextDouble()</code>, are delegated to instances of <code>java.util.Random</code>
+  that are seeded with the value of zero.
+
+  This technique of mapping instances to different instances can also be useful in cases
+  where it is desirable to have different types between the original receiver and the object
+  replacing the original receiver.
+</p>
+
 <h2 id="specifying-behavior">Specifying expected code behavior (pre- and post-conditions)</h2>
 
 <p>


### PR DESCRIPTION
Adds default replacements for the class `java.util.Random`, for instance methods such as `nextInt()`, `nextDouble()`, `nextFloat()`, and `nextLong()`.  This is necessary because Randoop does not yet support replacing constructor calls.

A small test case with an example class and the command is located here:
https://github.com/huangwaylon/test_randoop