### PR TITLE
Change isSubtype so raw Comparable is a subtype of Comparable<T>

### DIFF
--- a/src/main/java/randoop/types/ClassOrInterfaceType.java
+++ b/src/main/java/randoop/types/ClassOrInterfaceType.java
@@ -425,6 +425,11 @@ public abstract class ClassOrInterfaceType extends ReferenceType {
     if (super.isSubtypeOf(otherType)) {
       return true;
     }
+    if ((this instanceof NonParameterizedType)
+        && otherType.isGeneric()
+        && (this.getRuntimeClass() == otherType.getRuntimeClass())) {
+      return true;
+    }
 
     if (!otherType.isReferenceType()) {
       return false;


### PR DESCRIPTION
Perhaps a better fix is to get the generic interfaces of a class.