### PR TITLE
Ignores observer methods with nonzero parameters in asserts

### DIFF
--- a/src/main/java/randoop/test/RegressionCaptureGenerator.java
+++ b/src/main/java/randoop/test/RegressionCaptureGenerator.java
@@ -182,7 +182,10 @@ public final class RegressionCaptureGenerator extends TestCheckGenerator {
             Set<TypedOperation> observers = observerMap.getValues(var0.getType());
             if (observers != null) {
               for (TypedOperation m : observers) {
-
+                if (m.getInputTypes().size() > 1) {
+                    continue;
+                }
+                
                 ExecutionOutcome outcome = m.execute(new Object[] {runtimeValue}, null);
                 if (outcome instanceof ExceptionalExecution) {
                   String msg =


### PR DESCRIPTION
This change ignores observer methods with nonzero parameters in asserts instead of throwing an exception on execute() with the single runtimeValue.