### PR TITLE
 Rename --print-file-system-state to --print-erroneous-file

### DIFF
--- a/src/docs/CHANGES.txt
+++ b/src/docs/CHANGES.txt
@@ -1,8 +1,10 @@
 Version 4.0.4, released ??, 2018
 
-Randoop's replacecalls agent can now replace constructors.
+Command-line argument changes:
+ * the --specifications command-line argument can now be a .zip file
+ * renamed --print-file-system-state to --print-erroneous-file
 
-The --specifications command-line argument can now be a .zip file.
+Randoop's replacecalls agent can now replace constructors.
 
 
 Version 4.0.3, released April 10, 2018

--- a/src/docs/manual/index.html
+++ b/src/docs/manual/index.html
@@ -1230,7 +1230,7 @@ Randoop about your application, and that is how we recommend using Randoop.
  logging is done.
             <li id="option:operation-history-log"><b>--operation-history-log=</b><i>filename</i>.
              A file to which to log the operation usage history.
-            <li id="option:print-file-system-state"><b>--print-file-system-state=</b><i>boolean</i>.
+            <li id="option:print-erroneous-file"><b>--print-erroneous-file=</b><i>boolean</i>.
              Display source if a generated test contains a compilation error. [default false]
       </ul>
   <li id="optiongroup:Advanced-extension-points">Advanced extension points

--- a/src/main/java/randoop/main/GenInputsAbstract.java
+++ b/src/main/java/randoop/main/GenInputsAbstract.java
@@ -709,7 +709,7 @@ public abstract class GenInputsAbstract extends CommandHandler {
   public static FileWriter operation_history_log = null;
 
   @Option("Display source if a generated test contains a compilation error.")
-  public static boolean print_file_system_state = false;
+  public static boolean print_erroneous_file = false;
 
   /**
    * Create sequences but never execute them. Used to test performance of Randoop's sequence

--- a/src/main/java/randoop/output/FailingTestFilter.java
+++ b/src/main/java/randoop/output/FailingTestFilter.java
@@ -301,9 +301,15 @@ public class FailingTestFilter implements CodeWriter {
           message.append(String.format("Source file:%n%s%n", javaCode));
         } else {
           // TODO: print the whole method.
-          int fromLine = Math.max(0, lineNumber - 11);
-          int toLine = Math.min(lineNumber + 10, javaCodeLines.length);
-          message.append(String.format("Context:%n"));
+          int fromLine = lineNumber - 1;
+          while (fromLine > 0 && !javaCodeLines[fromLine].contains("@Test")) {
+            fromLine--;
+          }
+          int toLine = lineNumber;
+          while (toLine < javaCodeLines.length - 1 && !javaCodeLines[fromLine].contains("@Test")) {
+            toLine++;
+          }
+          message.append(String.format("Containing method:%n"));
           for (int i = fromLine; i < toLine; i++) {
             message.append(String.format("%s%n", javaCodeLines[i]));
           }

--- a/src/main/java/randoop/output/FailingTestFilter.java
+++ b/src/main/java/randoop/output/FailingTestFilter.java
@@ -282,7 +282,7 @@ public class FailingTestFilter implements CodeWriter {
       if (lineNumber < 1 || lineNumber > javaCodeLines.length) {
         throw new BugInRandoopException(
             String.format(
-                "Line number %d read from JUnit out of range [1,%d]: %s",
+                "Line number %d read from JUnit is out of range [1,%d]: %s",
                 lineNumber, javaCodeLines.length, failureLineMatch.line));
       }
 

--- a/src/systemtest/java/randoop/main/RandoopOptions.java
+++ b/src/systemtest/java/randoop/main/RandoopOptions.java
@@ -58,6 +58,7 @@ class RandoopOptions {
     options.setFlag("deterministic");
     options.setOption("time_limit", "0");
     options.unsetFlag("minimize-error-test");
+    options.setFlag("print-erroneous-file");
 
     // Use value from environment variable if command-line argument was not set
     String selectionLog = System.getProperty("randoop.selection.log");

--- a/src/systemtest/java/randoop/main/RandoopOptions.java
+++ b/src/systemtest/java/randoop/main/RandoopOptions.java
@@ -58,7 +58,6 @@ class RandoopOptions {
     options.setFlag("deterministic");
     options.setOption("time_limit", "0");
     options.unsetFlag("minimize-error-test");
-    options.setFlag("print-erroneous-file");
 
     // Use value from environment variable if command-line argument was not set
     String selectionLog = System.getProperty("randoop.selection.log");


### PR DESCRIPTION
Improve output even when it is not set.
Set it by default in system tests, to make Travis failures easier to debug.