### PR TITLE
don't break the build in case of htmlSanityCheck errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -865,7 +865,7 @@ htmlSanityCheck {
     sourceDocuments = fileTree(sourceDir) {
         include "index.html", "projectideas.html", "publications.html", "manual/dev.html", "manual/index.html"
     }
-    failOnErrors = true
+    failOnErrors = false //false means: don't break the build in case of errors
 }
 
 build.dependsOn manual


### PR DESCRIPTION
just a suggestion: if you (@mernst) don't want to break the build in case of htmlSanityCheck errors, use this configuration...

best regards, Gernot