### PR TITLE
Enable debug logging in CallReplaceTransformer

### DIFF
--- a/agent/replacecall/src/main/java/randoop/instrument/CallReplacementTransformer.java
+++ b/agent/replacecall/src/main/java/randoop/instrument/CallReplacementTransformer.java
@@ -236,7 +236,7 @@ public class CallReplacementTransformer extends InstructionListUtils
    * @return true if the class has been transformed, false otherwise
    * @throws IllegalClassFormatException if an unexpected instruction is found where an invoke is
    *     expected
-   * @throws IOException from somewhere?
+   * @throws IOException if there is trouble with writing to a file
    */
   private boolean transformClass(ClassGen cg) throws IllegalClassFormatException, IOException {
     // Have we modified this class?

--- a/agent/replacecall/src/main/java/randoop/instrument/CallReplacementTransformer.java
+++ b/agent/replacecall/src/main/java/randoop/instrument/CallReplacementTransformer.java
@@ -1,6 +1,8 @@
 package randoop.instrument;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.IllegalClassFormatException;
 import java.nio.file.Path;
@@ -40,16 +42,14 @@ public class CallReplacementTransformer extends InstructionListUtils
   /** Debug information about which classes are transformed and why. */
   private static SimpleLog debug_transform =
       new SimpleLog(
-          // ReplaceCallAgent.debugPath + File.separator + "replacecall-transform-log.txt",
-          // ReplaceCallAgent.debug);
-          false);
+          ReplaceCallAgent.debugPath + File.separator + "replacecall-transform-log.txt",
+          ReplaceCallAgent.debug);
 
   /** Debug information on method mapping. */
   private static SimpleLog debug_map =
       new SimpleLog(
-          // ReplaceCallAgent.debugPath + File.separator + "replacecall-method_mapping.txt",
-          // ReplaceCallAgent.debug);
-          false);
+          ReplaceCallAgent.debugPath + File.separator + "replacecall-method_mapping.txt",
+          ReplaceCallAgent.debug);
 
   // debug_instrument field is defined in InstructionListUtils.
 
@@ -73,8 +73,6 @@ public class CallReplacementTransformer extends InstructionListUtils
     this.replacementMap = replacementMap;
     this.excludedPackagePrefixes = excludedPackagePrefixes;
     // debug_instrument.enabled = ReplaceCallAgent.debug;
-    // debug_transform.enabled = ReplaceCallAgent.debug;
-    // debug_map.enabled = ReplaceCallAgent.debug;
   }
 
   /**
@@ -99,9 +97,10 @@ public class CallReplacementTransformer extends InstructionListUtils
 
     debug_transform.log("loader: %s, className: %s%n", loader, className);
 
-    // Note: An uncaught exception within a transform method is equivalent to null being returned.
+    // Note: An uncaught exception within the transform method is equivalent to null being returned.
     // This method might throw an IllegalClassFormatException, which is a ClassFileTransformer
-    // convention.  (It may re-throw a ThreadDeath error.)
+    // convention.  It may re-throw a ThreadDeath error.  It catches other Throwable exceptions
+    // and simply returns null.
 
     // In Java 8 the className is null for special Lambda classes. They should be ignored.
     // In Java 9 these special classes are not passed to the transform method.
@@ -123,7 +122,10 @@ public class CallReplacementTransformer extends InstructionListUtils
       ClassParser parser = new ClassParser(new ByteArrayInputStream(classfileBuffer), className);
       c = parser.parse();
     } catch (Exception e) {
-      debug_transform.log("transform: EXIT parse of %s resulted in error %s%n", className, e);
+      debug_transform.log("transform class: EXIT parse of %s resulted in error %s%n", className, e);
+      System.out.format(
+          "Unexpected exception %s (%s) in ClassParser.parse(%s)%n", e, e.getCause(), className);
+      e.printStackTrace(System.out);
       return null;
     }
 
@@ -136,11 +138,11 @@ public class CallReplacementTransformer extends InstructionListUtils
           Path filepath = ReplaceCallAgent.debugPath.resolve(className + ".class");
           javaClass.dump(filepath.toFile());
         }
-        debug_transform.log("transform: EXIT class %s transformed%n", className);
+        debug_transform.log("transform class: EXIT %s transformed%n", className);
         return javaClass.getBytes();
       } else {
         debug_transform.log(
-            "transform: EXIT class %s not transformed (nothing to replace)%n", className);
+            "transform class: EXIT %s not transformed (nothing to replace)%n", className);
         return null;
       }
     } catch (ThreadDeath e) {
@@ -148,14 +150,14 @@ public class CallReplacementTransformer extends InstructionListUtils
       throw e;
     } catch (IllegalClassFormatException e) {
       debug_transform.log(
-          "transform: EXIT transform of %s resulted in exception %s%n", className, e);
+          "transform class: EXIT transform of %s resulted in exception %s%n", className, e);
       System.out.format(
           "Unexpected exception %s (cause=%s) in CallReplacementTransformer.transform(%s)%n",
           e, e.getCause(), className);
       throw e;
     } catch (Throwable e) {
       debug_transform.log(
-          "transform: EXIT transform of %s resulted in exception %s%n", className, e);
+          "transform class: EXIT transform of %s resulted in exception %s%n", className, e);
       System.out.format(
           "Unexpected exception %s (%s) in CallReplacementTransformer.transform(%s)%n",
           e, e.getCause(), className);
@@ -234,17 +236,18 @@ public class CallReplacementTransformer extends InstructionListUtils
    * @return true if the class has been transformed, false otherwise
    * @throws IllegalClassFormatException if an unexpected instruction is found where an invoke is
    *     expected
+   * @throws IOException from somewhere?
    */
-  private boolean transformClass(ClassGen cg) throws IllegalClassFormatException {
+  private boolean transformClass(ClassGen cg) throws IllegalClassFormatException, IOException {
     // Have we modified this class?
     boolean transformed = false;
     InstructionFactory ifact = new InstructionFactory(cg);
     boolean save_debug = debug_instrument.enabled;
 
-    try {
-      // Loop through each method in the class
-      for (Method method : cg.getMethods()) {
+    // Loop through each method in the class
+    for (Method method : cg.getMethods()) {
 
+      try {
         // The class data in StackMapUtils is not thread safe,
         // allow only one method at a time to be instrumented.
         synchronized (this) {
@@ -313,11 +316,11 @@ public class CallReplacementTransformer extends InstructionListUtils
               mg.getClassName(), mg.getName(), mg.getMethod().getCode());
           cg.update();
         }
+      } catch (Exception e) {
+        System.out.printf("Unexpected exception processing method %s%n", method.getName());
+        debug_instrument.enabled = save_debug;
+        throw e;
       }
-    } catch (Exception e) {
-      System.out.printf("Unexpected exception encountered: %s%n", e);
-      e.printStackTrace(System.out);
-      debug_instrument.enabled = save_debug;
     }
 
     return transformed;
@@ -540,7 +543,7 @@ public class CallReplacementTransformer extends InstructionListUtils
                 origInvocation, mg.getClassName(), mg.getName());
         throw new IllegalClassFormatException(msg);
     }
-    debug_transform.log("new invoke: %s%n", newInvocation);
+    // debug_transform.log("new invoke: %s%n", newInvocation);
     return build_il(newInvocation);
   }
 


### PR DESCRIPTION
Enable deubg logging now that SimpleLog supports output to file.
Improve documentation and handling of exceptions.