### PR TITLE
Classpath from manifest

### DIFF
--- a/src/main/java/randoop/main/GenInputsAbstract.java
+++ b/src/main/java/randoop/main/GenInputsAbstract.java
@@ -1180,7 +1180,7 @@ public abstract class GenInputsAbstract extends CommandHandler {
       String packageName, AccessibilityPredicate accessibility) {
     List<@ClassGetName String> classnames = new ArrayList<>();
 
-    for (String path : Globals.getClassPath().split(File.pathSeparator)) {
+    for (String path : Globals.getClassPathEntries()) {
       File location = new File(path);
       if (location.isFile() && location.getName().endsWith(".jar")) {
         classnames.addAll(getClassesWithPackageFromJar(location, packageName, accessibility));


### PR DESCRIPTION
Hello! I faced a problem when using `--test-package`. Now this option searches only in places defined by `java.class.path` system property. Some jars may include META-INF/MANIFEST.MF with `Class-Path` attribute. If needed classes are in place defined by manifest instead of `java.class.path` they cannot be found, despite they are available to JVM. To solve that, I added method that returns classpath entries both from `java.class.path` property and manifest files.