### PR TITLE
Support escaping dollar sign from variable name

### DIFF
--- a/src/main/java/randoop/contract/ObjectContractUtils.java
+++ b/src/main/java/randoop/contract/ObjectContractUtils.java
@@ -1,5 +1,6 @@
 package randoop.contract;
 
+import java.util.regex.Matcher;
 import randoop.ExecutionOutcome;
 import randoop.sequence.Variable;
 import randoop.util.ObjectContractReflectionCode;
@@ -36,7 +37,7 @@ public class ObjectContractUtils {
     for (int i = 0; i < vars.length; i++) {
       // See documentation for ObjectContract.toCommentString().
       String pattern = "\\bx" + i + "\\b";
-      str = str.replaceAll(pattern, vars[i].getName());
+      str = str.replaceAll(pattern, Matcher.quoteReplacement(vars[i].getName()));
     }
     return str;
   }


### PR DESCRIPTION
I have tried running Randoop 4.2.6 on a set of classes in Spark 3.2.0 and encountered the following issue.

```
scala.collection.generic.GenTraversableFactory.GenericCanBuildFrom<scala.runtime.Nothing$> nothing$GenericCanBuildFrom0 = scala.collection.Seq.ReusableCBF(); // [NormalExecution scala.collection.generic.GenTraversableFactory$$anon$1@6bc246c0 [class scala.collection.generic.GenTraversableFactory$$anon$1]]
<randoop.contract.IsNotNull@1f [nothing$GenericCanBuildFrom0]>
randoop.main.RandoopBug: Problem with ObjectCheck <randoop.contract.IsNotNull@1f [nothing$GenericCanBuildFrom0]>
    at randoop.test.ObjectCheck.toCodeStringPostStatement(ObjectCheck.java:99)
    at randoop.sequence.ExecutableSequence.toCodeLines(ExecutableSequence.java:186)
    at randoop.sequence.ExecutableSequence.toCodeString(ExecutableSequence.java:206)
    at randoop.output.JUnitCreator.createTestMethod(JUnitCreator.java:305)
    at randoop.output.JUnitCreator.createTestClass(JUnitCreator.java:262)
    at randoop.test.CompilableTestPredicate.test(CompilableTestPredicate.java:78)
    at randoop.test.CompilableTestPredicate.test(CompilableTestPredicate.java:20)
    at java.util.function.Predicate.lambda$and$0(Predicate.java:69)
    at randoop.generation.AbstractGenerator.createAndClassifySequences(AbstractGenerator.java:346)
    at randoop.main.GenTests.handle(GenTests.java:514)
    at randoop.main.Main.nonStaticMain(Main.java:71)
    at randoop.main.Main.main(Main.java:31)
Caused by: java.lang.IllegalArgumentException: Illegal group reference
    at java.util.regex.Matcher.appendReplacement(Matcher.java:857)
    at java.util.regex.Matcher.replaceAll(Matcher.java:955)
    at java.lang.String.replaceAll(String.java:2223)
    at randoop.contract.ObjectContractUtils.localizeContractCode(ObjectContractUtils.java:39)
    at randoop.test.ObjectCheck.toCodeStringPostStatement(ObjectCheck.java:97)
    ... 11 more

createAndClassifySequences threw an exception
randoop.main.RandoopBug: Problem with ObjectCheck <randoop.contract.IsNotNull@1f [nothing$GenericCanBuildFrom0]>
    at randoop.test.ObjectCheck.toCodeStringPostStatement(ObjectCheck.java:99)
    at randoop.sequence.ExecutableSequence.toCodeLines(ExecutableSequence.java:186)
    at randoop.sequence.ExecutableSequence.toCodeString(ExecutableSequence.java:206)
    at randoop.output.JUnitCreator.createTestMethod(JUnitCreator.java:305)
    at randoop.output.JUnitCreator.createTestClass(JUnitCreator.java:262)
    at randoop.test.CompilableTestPredicate.test(CompilableTestPredicate.java:78)
    at randoop.test.CompilableTestPredicate.test(CompilableTestPredicate.java:20)
    at java.util.function.Predicate.lambda$and$0(Predicate.java:69)
    at randoop.generation.AbstractGenerator.createAndClassifySequences(AbstractGenerator.java:346)
    at randoop.main.GenTests.handle(GenTests.java:514)
    at randoop.main.Main.nonStaticMain(Main.java:71)
    at randoop.main.Main.main(Main.java:31)
Caused by: java.lang.IllegalArgumentException: Illegal group reference
    at java.util.regex.Matcher.appendReplacement(Matcher.java:857)
    at java.util.regex.Matcher.replaceAll(Matcher.java:955)
    at java.lang.String.replaceAll(String.java:2223)
    at randoop.contract.ObjectContractUtils.localizeContractCode(ObjectContractUtils.java:39)
    at randoop.test.ObjectCheck.toCodeStringPostStatement(ObjectCheck.java:97)
```

This bug is caused by Randoop naming a variable `nothing$GenericCanBuildFrom0` using a `$` character that is not correctly escaped in a `replaceAll` call in `localizeContractCode`.

Here is a small example that reproduces the bug on both Java 8 and 17.
```
echo 'public class C$ { public java.util.Set<C$> m() { return null; } }' >C$.java
javac C$.java
java -cp $RANDOOP_HOME/randoop-all-4.2.6.jar:. randoop.main.Main gentests --testclass=C$
```