### PR TITLE
Fix typo in manual

### DIFF
--- a/src/docs/manual/index.html
+++ b/src/docs/manual/index.html
@@ -2029,7 +2029,7 @@ exception escaping the method as the rep invariant being violated.
 
 <p>
   If you want to test a particular class or method, do <em>not</em> attempt
-  to use the <code>--methodList</code>, <code>--classlist</code>, or
+  to use the <code>--methodlist</code>, <code>--classlist</code>, or
   similar command-line options.  They restrict the methods that appear
   anywhere in a test, and are likely to lead to Randoop not producing any
   output.


### PR DESCRIPTION
Change `--methodList` to `--methodlist`.