### PR TITLE
Remove Gradle deprecation warings.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,8 +36,10 @@ allprojects {
   apply plugin: 'com.github.johnrengelman.shadow'
   apply plugin: 'net.ltgt.errorprone'
 
-  sourceCompatibility = 1.8
-  targetCompatibility = 1.8
+  java {
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
+  }
 
   repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -672,7 +672,7 @@ task distributionZip (type: Zip , dependsOn: [
 ]) {
   group 'Publishing'
   description 'Assemble a zip file with jar files and user documentation'
-  def dirName = "${project.archivesBaseName}-${project.version}"
+  def dirName = "${base.archivesBaseName}-${version}"
   from 'build/libs/'
   from ('src/docs/manual/index.html') {
     into 'doc/manual'


### PR DESCRIPTION
The Checker Framework plugin still has deprecation warnings.