### PR TITLE
Unify Checker Framework versions.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
 
   id('net.ltgt.errorprone') version '3.1.0'
 
-  id 'org.checkerframework' version '0.6.32'
+  id 'org.checkerframework' version '0.6.33'
 
   id 'org.aim42.htmlSanityCheck' version '1.1.6'
 
@@ -189,7 +189,10 @@ dependencies {
   implementation 'org.apache.commons:commons-exec:1.3'
   implementation 'org.apache.commons:commons-lang3:3.13.0'
   implementation 'org.checkerframework.annotatedlib:commons-io:2.8.0.1'
+
+  compileOnly "org.checkerframework:checker-qual:$checkerFrameworkVersion"
   implementation "org.checkerframework:checker-qual:$checkerFrameworkVersion"
+  checkerFramework "org.checkerframework:checker:$checkerFrameworkVersion"
 
   /* Jacoco measures coverage of classes and methods under test. */
   implementation "org.jacoco:org.jacoco.core:$jacocoVersion"


### PR DESCRIPTION
Make sure the the Checker Framework plugin uses the same version of the Checker Framework that is used as a dependencies of the project.  This should fix the failures in #1238 and #1237. 