### PR TITLE
Add forbid null flag (#1344)

### DIFF
--- a/src/main/java/randoop/generation/ForwardGenerator.java
+++ b/src/main/java/randoop/generation/ForwardGenerator.java
@@ -717,6 +717,7 @@ public class ForwardGenerator extends AbstractGenerator {
       // The user may have requested that we use null values as inputs with some given frequency.
       // If this is the case, then use null instead with some probability.
       if (!isReceiver
+          && !GenInputsAbstract.forbid_null
           && GenInputsAbstract.null_ratio != 0
           && Randomness.weightedCoinFlip(GenInputsAbstract.null_ratio)) {
         Log.logPrintf("Using null as input.%n");


### PR DESCRIPTION
Using randoop, i could observe that setting forbid-null=true does not forbid null actually. Adding this change in the if statement condition does it.