### PR TITLE
Check if superclass is enum in isEnum method. 

### DIFF
--- a/src/main/java/randoop/types/NonParameterizedType.java
+++ b/src/main/java/randoop/types/NonParameterizedType.java
@@ -175,7 +175,7 @@ public class NonParameterizedType extends ClassOrInterfaceType {
 
   @Override
   public boolean isEnum() {
-    return runtimeType.isEnum();
+    return runtimeType.isEnum() || (getRuntimeClass().getSuperclass() != null && getRuntimeClass().getSuperclass().isEnum());
   }
 
   /**

--- a/src/main/java/randoop/types/NonParameterizedType.java
+++ b/src/main/java/randoop/types/NonParameterizedType.java
@@ -175,6 +175,8 @@ public class NonParameterizedType extends ClassOrInterfaceType {
 
   @Override
   public boolean isEnum() {
+    // Check if the runtime type is an enum or if the type is an Enum Constant which is a subclass
+    // of enum
     return runtimeType.isEnum()
         || (getRuntimeClass().getSuperclass() != null
             && getRuntimeClass().getSuperclass().isEnum());

--- a/src/main/java/randoop/types/NonParameterizedType.java
+++ b/src/main/java/randoop/types/NonParameterizedType.java
@@ -175,8 +175,8 @@ public class NonParameterizedType extends ClassOrInterfaceType {
 
   @Override
   public boolean isEnum() {
-    // Check if the runtime type is an enum or if the type is an Enum Constant which is a subclass
-    // of enum
+    // Return true if the run-time type is an enum type or is an enum constant.  An enum constant is
+    // represented (by the javac compiler) as a subclass of an enum type.
     return runtimeType.isEnum()
         || (getRuntimeClass().getSuperclass() != null
             && getRuntimeClass().getSuperclass().isEnum());

--- a/src/main/java/randoop/types/NonParameterizedType.java
+++ b/src/main/java/randoop/types/NonParameterizedType.java
@@ -175,7 +175,9 @@ public class NonParameterizedType extends ClassOrInterfaceType {
 
   @Override
   public boolean isEnum() {
-    return runtimeType.isEnum() || (getRuntimeClass().getSuperclass() != null && getRuntimeClass().getSuperclass().isEnum());
+    return runtimeType.isEnum()
+        || (getRuntimeClass().getSuperclass() != null
+            && getRuntimeClass().getSuperclass().isEnum());
   }
 
   /**


### PR DESCRIPTION
This caused an issue when using demand driven on the easymock library.