### PR TITLE
Fix Value.toCodeString to Correctly Handle Enum Instances of Anonymous Subclasses

### DIFF
--- a/src/main/java/randoop/sequence/Value.java
+++ b/src/main/java/randoop/sequence/Value.java
@@ -33,7 +33,7 @@ public class Value {
     }
 
     Type valueType = Type.forClass(value.getClass());
-    assert (valueType.isNonreceiverType() || valueType.isEnum())
+    assert (valueType.isNonreceiverType() || value instanceof Enum)
         : "expecting nonreceiver type or enum: " + valueType;
 
     if (valueType.isString()) {

--- a/src/main/java/randoop/sequence/Value.java
+++ b/src/main/java/randoop/sequence/Value.java
@@ -48,7 +48,7 @@ public class Value {
       return ((Class<?>) value).getCanonicalName() + ".class";
     }
 
-    if (valueType.isEnum()) {
+    if (value instanceof Enum) {
       return new EnumValue((Enum<?>) value).getValueName();
     }
 

--- a/src/systemTest/java/randoop/main/RandoopSystemTest.java
+++ b/src/systemTest/java/randoop/main/RandoopSystemTest.java
@@ -1933,6 +1933,25 @@ public class RandoopSystemTest {
     generateAndTest(testEnvironment, options, ExpectedTests.SOME, ExpectedTests.NONE);
   }
 
+  @Test
+  public void AnonymousEnumTest() {
+    SystemTestEnvironment testEnvironment =
+        systemTestEnvironmentManager.createTestEnvironment("anonymous-enum");
+    RandoopOptions options = createRandoopOptions(testEnvironment);
+    options.addTestClass("enums.BoundType");
+    options.setOption("output_limit", "3");
+
+    CoverageChecker coverageChecker =
+            new CoverageChecker(
+                    options,
+                    "enums.BoundType.flip() ignore",
+                    "enums.BoundType.forBoolean(boolean) ignore",
+                    "enums.BoundType.valueOf(java.lang.String) ignore",
+                    "enums.BoundType.values() ignore");
+    
+    generateAndTest(testEnvironment, options, ExpectedTests.SOME, ExpectedTests.NONE, coverageChecker);
+  }
+
   /* ------------------------------ utility methods ---------------------------------- */
 
   /**

--- a/src/systemTest/java/randoop/main/RandoopSystemTest.java
+++ b/src/systemTest/java/randoop/main/RandoopSystemTest.java
@@ -1942,14 +1942,15 @@ public class RandoopSystemTest {
     options.setOption("output_limit", "3");
 
     CoverageChecker coverageChecker =
-            new CoverageChecker(
-                    options,
-                    "enums.BoundType.flip() ignore",
-                    "enums.BoundType.forBoolean(boolean) ignore",
-                    "enums.BoundType.valueOf(java.lang.String) ignore",
-                    "enums.BoundType.values() ignore");
-    
-    generateAndTest(testEnvironment, options, ExpectedTests.SOME, ExpectedTests.NONE, coverageChecker);
+        new CoverageChecker(
+            options,
+            "enums.BoundType.flip() ignore",
+            "enums.BoundType.forBoolean(boolean) ignore",
+            "enums.BoundType.valueOf(java.lang.String) ignore",
+            "enums.BoundType.values() ignore");
+
+    generateAndTest(
+        testEnvironment, options, ExpectedTests.SOME, ExpectedTests.NONE, coverageChecker);
   }
 
   /* ------------------------------ utility methods ---------------------------------- */

--- a/src/systemTest/java/randoop/main/RandoopSystemTest.java
+++ b/src/systemTest/java/randoop/main/RandoopSystemTest.java
@@ -1939,7 +1939,7 @@ public class RandoopSystemTest {
         systemTestEnvironmentManager.createTestEnvironment("anonymous-enum");
     RandoopOptions options = createRandoopOptions(testEnvironment);
     options.addTestClass("enums.BoundType");
-    options.setOption("output_limit", "3");
+    options.setOption("output_limit", "5");
 
     CoverageChecker coverageChecker =
         new CoverageChecker(

--- a/src/testInput/java/enums/BoundType.java
+++ b/src/testInput/java/enums/BoundType.java
@@ -10,38 +10,30 @@ package enums;
  * bound simply does not exist.
  */
 public enum BoundType {
-    /**
-     * The endpoint value <i>is not</i> considered part of the set ("exclusive").
-     */
-    OPEN {
-        @Override
-        BoundType flip() {
-            return CLOSED;
-        }
-    },
-    /**
-     * The endpoint value <i>is</i> considered part of the set ("inclusive").
-     */
-    CLOSED {
-        @Override
-        BoundType flip() {
-            return OPEN;
-        }
-    };
-
-    /**
-     * Returns the bound type corresponding to a boolean value for inclusivity.
-     */
-    static BoundType forBoolean(boolean inclusive) {
-        return inclusive ? CLOSED : OPEN;
+  /** The endpoint value <i>is not</i> considered part of the set ("exclusive"). */
+  OPEN {
+    @Override
+    BoundType flip() {
+      return CLOSED;
     }
-
-    /**
-     * Returns an array of all the enum values.
-     */
-    public static BoundType[] getValues() {
-        return values();
+  },
+  /** The endpoint value <i>is</i> considered part of the set ("inclusive"). */
+  CLOSED {
+    @Override
+    BoundType flip() {
+      return OPEN;
     }
+  };
 
-    abstract BoundType flip();
+  /** Returns the bound type corresponding to a boolean value for inclusivity. */
+  static BoundType forBoolean(boolean inclusive) {
+    return inclusive ? CLOSED : OPEN;
+  }
+
+  /** Returns an array of all the enum values. */
+  public static BoundType[] getValues() {
+    return values();
+  }
+
+  abstract BoundType flip();
 }

--- a/src/testInput/java/enums/BoundType.java
+++ b/src/testInput/java/enums/BoundType.java
@@ -1,0 +1,47 @@
+package enums;
+
+/*
+ * Modified from Guava 16.0.1 BoundType.java
+ */
+
+/**
+ * Indicates whether an endpoint of some range is contained in the range itself ("closed") or not
+ * ("open"). If a range is unbounded on a side, it is neither open nor closed on that side; the
+ * bound simply does not exist.
+ */
+public enum BoundType {
+    /**
+     * The endpoint value <i>is not</i> considered part of the set ("exclusive").
+     */
+    OPEN {
+        @Override
+        BoundType flip() {
+            return CLOSED;
+        }
+    },
+    /**
+     * The endpoint value <i>is</i> considered part of the set ("inclusive").
+     */
+    CLOSED {
+        @Override
+        BoundType flip() {
+            return OPEN;
+        }
+    };
+
+    /**
+     * Returns the bound type corresponding to a boolean value for inclusivity.
+     */
+    static BoundType forBoolean(boolean inclusive) {
+        return inclusive ? CLOSED : OPEN;
+    }
+
+    /**
+     * Returns an array of all the enum values.
+     */
+    public static BoundType[] getValues() {
+        return values();
+    }
+
+    abstract BoundType flip();
+}


### PR DESCRIPTION
The old condition fails for enum constants that are instances of anonymous inner classes when they override methods. In such cases, `value.getClass().isEnum()` and `valueType.isEnum()` return false, leading to the object being incorrectly treated as a numeric type, and fails Randoop.