### PR TITLE
Fix directory name for the distribution zip

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -736,7 +736,7 @@ task distributionZip (type: Zip , dependsOn: [
 ]) {
   group = 'Publishing'
   description = 'Assemble a zip file with jar files and user documentation'
-  def dirName = "${base.archivesName}-${version}"
+  def dirName = "${base.archivesName.get()}-${version}"
   from 'build/libs/'
   from ('src/docs/manual/index.html') {
     into 'doc/manual'


### PR DESCRIPTION
After unzip the current release file [randoop-4.3.4.zip](https://github.com/randoop/randoop/releases/download/v4.3.4/randoop-4.3.4.zip), a directory named `extension 'base' property 'archivesName'-4.3.4` will be created.

This PR fixes the `build.gradle` to correctly set the name. With the fix, unzipping `randoop-4.3.4.zip` will create a dir named `randoop-4.3.4`.