### PR TITLE
Improve `clear()`

### DIFF
--- a/src/main/java/randoop/sequence/SequenceCollection.java
+++ b/src/main/java/randoop/sequence/SequenceCollection.java
@@ -77,6 +77,7 @@ public class SequenceCollection {
     Log.logPrintf("Clearing sequence collection.%n");
     this.sequenceMap = new LinkedHashMap<>();
     this.typeSet = new SubTypeSet(false);
+    this.typesAndSupertypes = new TreeSet<>();
     this.sequenceCount = 0;
     checkRep();
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clearing collections now fully resets internal caches, preventing stale type information from persisting after a clear operation.
  * Ensures subsequent runs start from a clean state, avoiding unexpected behavior and improving consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->