### PR TITLE
CircleCI: add dependences, test under JDK 24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,10 +359,10 @@ jobs:
       - store_artifacts:
           path: ~/test-results/junit
 
-  nonSystemTest-jdk22:
+  nonSystemTest-jdk24:
 
     docker:
-      - image: mdernst/randoop-ubuntu-jdk22
+      - image: mdernst/randoop-ubuntu-jdk24
 
     steps:
 
@@ -402,10 +402,10 @@ jobs:
       - store_artifacts:
           path: ~/test-results/junit
 
-  systemTest-jdk22:
+  systemTest-jdk24:
 
     docker:
-      - image: mdernst/randoop-ubuntu-jdk22
+      - image: mdernst/randoop-ubuntu-jdk24
 
     steps:
 
@@ -501,11 +501,11 @@ workflows:
             - systemTest-jdk21
       - nonSystemTest-jdk21
       - systemTest-jdk21
-      - nonSystemTest-jdk22:
+      - nonSystemTest-jdk24:
           requires:
             - misc
             - nonSystemTest-jdk21
-      - systemTest-jdk22:
+      - systemTest-jdk24:
           requires:
             - misc
             - systemTest-jdk21

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -483,12 +483,30 @@ workflows:
   version: 2
   build:
     jobs:
-      - nonSystemTest-jdk11
-      - systemTest-jdk11
-      - nonSystemTest-jdk17
-      - systemTest-jdk17
+      - nonSystemTest-jdk11:
+          requires:
+            - misc
+            - nonSystemTest-jdk21
+      - systemTest-jdk11:
+          requires:
+            - misc
+            - systemTest-jdk21
+      - nonSystemTest-jdk17:
+          requires:
+            - misc
+            - nonSystemTest-jdk21
+      - systemTest-jdk17:
+          requires:
+            - misc
+            - systemTest-jdk21
       - nonSystemTest-jdk21
       - systemTest-jdk21
-      - nonSystemTest-jdk22
-      - systemTest-jdk22
+      - nonSystemTest-jdk22:
+          requires:
+            - misc
+            - nonSystemTest-jdk21
+      - systemTest-jdk22:
+          requires:
+            - misc
+            - systemTest-jdk21
       - misc

--- a/src/docs/CHANGELOG.md
+++ b/src/docs/CHANGELOG.md
@@ -53,7 +53,7 @@ Version 4.3.0 (January 31, 2022)
 
 Randoop supports Java 17 (and still supports Java 8 and Java 11).
 
-Removed command-line argiments `--omitmethods` and `--omitmethods-file`,
+Removed command-line arguments `--omitmethods` and `--omitmethods-file`,
 which were deprecated two years ago.
 
 Support escaping dollar sign from variable name.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New in CI/Chores
  - Updated continuous integration test matrix to include JDK 24 and solidify JDK 21 as a gating stage.
  - Retired JDK 22 jobs and restructured workflows to run downstream JDK 11/17/24 tests after JDK 21 completes.
  - Improved reliability by aligning images and job dependencies across environments.

- Documentation
  - Corrected a typographical error in the changelog entry for version 4.3.0 (clarifying “arguments”).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->