### PR TITLE
Don't use multi-string dependency syntax in Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -229,7 +229,7 @@ dependencies {
 
   /* Jacoco measures coverage of classes and methods under test. */
   implementation "org.jacoco:org.jacoco.core:${versions.jacoco}"
-  implementation group: 'org.jacoco', name: 'org.jacoco.agent', version: "${versions.jacoco}", classifier: 'runtime'
+  implementation "org.jacoco:org.jacoco.agent:${versions.jacoco}:runtime"
 
   /* sourceSet test uses JUnit and some use testInput source set */
   testImplementation 'commons-codec:commons-codec:1.19.0'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to use modern notation for the code coverage agent dependency, improving consistency and maintainability.
  * No functional or behavioral changes to the application; this is a non-user-facing update.
  * Helps streamline dependency management and aligns with current tooling conventions.
  * End users should not notice any differences in features or performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->