### PR TITLE
Fix TF-IDF literal statistics inconsistency causing Randoop Bug

### DIFF
--- a/src/main/java/randoop/reflection/ClassLiteralExtractor.java
+++ b/src/main/java/randoop/reflection/ClassLiteralExtractor.java
@@ -61,8 +61,7 @@ class ClassLiteralExtractor extends DefaultClassVisitor {
       if (frequency <= 0) {
         continue;
       }
-      scopeToLiteralStatistics.incrementNumUses(
-          containingType, seq, frequency);
+      scopeToLiteralStatistics.incrementNumUses(containingType, seq, frequency);
       allConstants.add(seq);
     }
 

--- a/src/main/java/randoop/reflection/ClassLiteralExtractor.java
+++ b/src/main/java/randoop/reflection/ClassLiteralExtractor.java
@@ -54,8 +54,15 @@ class ClassLiteralExtractor extends DefaultClassVisitor {
       if (termValue == null) {
         continue;
       }
+      int frequency = constantSet.getConstantFrequency(termValue);
+      // Skip constants with zero or negative frequency. These appear in the constant pool
+      // (e.g., for static final field initializers) but have zero usage in executable bytecode
+      // Including these would create inconsistent statistics where numUses=0 but numClassesWith>0.
+      if (frequency <= 0) {
+        continue;
+      }
       scopeToLiteralStatistics.incrementNumUses(
-          containingType, seq, constantSet.getConstantFrequency(termValue));
+          containingType, seq, frequency);
       allConstants.add(seq);
     }
 


### PR DESCRIPTION
Fixed a bug where constants appearing only in static final field initializers were being tracked with zero usage frequency, causing RandoopBug exceptions in TfIdfSelector when [numUses=0] but [numClassesWith>0]. These constants appear in the bytecode constant pool but are never directly used in executable code. The fix skips any constant with frequency <= 0 during literal extraction, ensuring only genuinely used literals are mined for test generation.