### PR TITLE
Fix RandoopBug crash when type variable is uninstantiated in generic library methods

### DIFF
--- a/src/main/java/randoop/operation/TypedClassOperationWithCast.java
+++ b/src/main/java/randoop/operation/TypedClassOperationWithCast.java
@@ -5,6 +5,7 @@ import randoop.ExecutionOutcome;
 import randoop.NormalExecution;
 import randoop.condition.ExecutableSpecification;
 import randoop.types.ClassOrInterfaceType;
+import randoop.types.ParameterType;
 import randoop.types.Substitution;
 import randoop.types.Type;
 import randoop.types.TypeTuple;
@@ -69,6 +70,11 @@ public class TypedClassOperationWithCast extends TypedClassOperation {
     ExecutionOutcome outcome = super.execute(input);
     if (outcome instanceof NormalExecution) {
       NormalExecution execution = (NormalExecution) outcome;
+      // If the output type is an uninstantiated type variable, getRuntimeClass() would throw.
+      // In that case, skip the cast and return the value as-is.
+      if (getOutputType() instanceof ParameterType) {
+        return outcome;
+      }
       Object result;
       try {
         result = getOutputType().getRuntimeClass().cast(execution.getRuntimeValue());

--- a/src/main/java/randoop/types/ParameterType.java
+++ b/src/main/java/randoop/types/ParameterType.java
@@ -76,18 +76,22 @@ public abstract class ParameterType extends ReferenceType {
         String.format("no run-time class for a type variable %s [%s]", this, this.getClass()));
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Returns false: type variables are never primitive, boxed primitive, {@code String}, or
+   * {@code Class}, and calling the default implementation would invoke {@link #getRuntimeClass()}
+   * which throws for type variables.
+   */
   @Override
   public boolean isNonreceiverType() {
-    // Returns false: type variables are never primitive, boxed primitive, {@code String}, or {@code
-    // Class}, and calling the default implementation would invoke {@link #getRuntimeClass()} which
-    // throws for type variables.
     return false;
   }
 
   /**
    * Sets the upper bound of this type parameter.
    *
-   * @param upperBound the upper bound to set
+   * @param upperBound the new upper bound
    */
   void setUpperBound(ParameterBound upperBound) {
     this.upperBound = upperBound;
@@ -96,7 +100,7 @@ public abstract class ParameterType extends ReferenceType {
   /**
    * Sets the lower bound of this type parameter.
    *
-   * @param lowerBound the lower bound to set
+   * @param lowerBound the new lower bound
    */
   void setLowerBound(ParameterBound lowerBound) {
     this.lowerBound = lowerBound;

--- a/src/main/java/randoop/types/ParameterType.java
+++ b/src/main/java/randoop/types/ParameterType.java
@@ -84,10 +84,20 @@ public abstract class ParameterType extends ReferenceType {
     return false;
   }
 
+  /**
+   * Sets the upper bound of this type parameter.
+   *
+   * @param upperBound the upper bound to set
+   */
   void setUpperBound(ParameterBound upperBound) {
     this.upperBound = upperBound;
   }
 
+  /**
+   * Sets the lower bound of this type parameter.
+   *
+   * @param lowerBound the lower bound to set
+   */
   void setLowerBound(ParameterBound lowerBound) {
     this.lowerBound = lowerBound;
   }

--- a/src/main/java/randoop/types/ParameterType.java
+++ b/src/main/java/randoop/types/ParameterType.java
@@ -76,15 +76,11 @@ public abstract class ParameterType extends ReferenceType {
         String.format("no run-time class for a type variable %s [%s]", this, this.getClass()));
   }
 
-  /**
-   * Returns false: type variables are never primitive, boxed primitive, {@code String}, or {@code
-   * Class}, and calling the default implementation would invoke {@link #getRuntimeClass()} which
-   * throws for type variables.
-   *
-   * @return false
-   */
   @Override
   public boolean isNonreceiverType() {
+    // Returns false: type variables are never primitive, boxed primitive, {@code String}, or {@code
+    // Class}, and calling the default implementation would invoke {@link #getRuntimeClass()} which
+    // throws for type variables.
     return false;
   }
 

--- a/src/main/java/randoop/types/ParameterType.java
+++ b/src/main/java/randoop/types/ParameterType.java
@@ -76,6 +76,18 @@ public abstract class ParameterType extends ReferenceType {
         String.format("no run-time class for a type variable %s [%s]", this, this.getClass()));
   }
 
+  /**
+   * Returns false: type variables are never primitive, boxed primitive, {@code String}, or {@code
+   * Class}, and calling the default implementation would invoke {@link #getRuntimeClass()} which
+   * throws for type variables.
+   *
+   * @return false
+   */
+  @Override
+  public boolean isNonreceiverType() {
+    return false;
+  }
+
   void setUpperBound(ParameterBound upperBound) {
     this.upperBound = upperBound;
   }


### PR DESCRIPTION
## PR Description

**Problem**

Randoop crashes with `RandoopBug: no run-time class for a type variable` when analyzing or executing methods from generic library classes (e.g., ASM's `Frame<V>.merge(...)`) where the type variable `V` is never substituted with a concrete type. Two separate code paths hit this:

1. **Input selection**: `SequenceCollection.getSequencesForType()` calls `isNonreceiverType()` on a candidate type that is an uninstantiated `ExplicitTypeVariable`. The base implementation of `isNonreceiverType()` in `Type` calls `getRuntimeClass()`, which throws for all `ParameterType` instances.

2. **Execution**: `TypedClassOperationWithCast.execute()` tries to cast the return value of a method whose output type is still a type variable, again calling `getRuntimeClass()` and throwing.

**Fix**

- ParameterType.java: Override `isNonreceiverType()` to return `false` directly. A type variable can never be a primitive, boxed primitive, `String`, or `Class`, so no runtime class lookup is needed.

- TypedClassOperationWithCast.java: Guard the cast in `execute()` -- if the output type is a `ParameterType` (uninstantiated type variable), skip the cast and return the execution result as-is.