### PR TITLE
Ignore overly long class-file string constants

### DIFF
--- a/src/main/java/randoop/util/ClassFileConstants.java
+++ b/src/main/java/randoop/util/ClassFileConstants.java
@@ -45,6 +45,7 @@ import org.plumelib.util.MapsP;
 import randoop.main.RandoopBug;
 import randoop.operation.NonreceiverTerm;
 import randoop.reflection.TypeNames;
+import randoop.sequence.StringTooLongException;
 import randoop.types.JavaTypes;
 
 // Implementation notes:  All string, float, and double constants are in
@@ -877,7 +878,11 @@ public class ClassFileConstants {
       result.add(new NonreceiverTerm(JavaTypes.DOUBLE_TYPE, x));
     }
     for (String x : cs.strings) {
-      result.add(new NonreceiverTerm(JavaTypes.STRING_TYPE, x));
+      try {
+        result.add(new NonreceiverTerm(JavaTypes.STRING_TYPE, x));
+      } catch (StringTooLongException e) {
+        System.out.println("Ignoring String constant value: " + e.getMessage());
+      }
     }
     for (Class<?> x : cs.classes) {
       result.add(new NonreceiverTerm(JavaTypes.CLASS_TYPE, x));

--- a/src/test/java/randoop/util/ClassFileConstantsTest.java
+++ b/src/test/java/randoop/util/ClassFileConstantsTest.java
@@ -1,0 +1,47 @@
+package randoop.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Set;
+import org.junit.Test;
+import randoop.main.GenInputsAbstract;
+import randoop.operation.NonreceiverTerm;
+import randoop.types.JavaTypes;
+
+/** Tests for {@link ClassFileConstants}. */
+public class ClassFileConstantsTest {
+
+  @Test
+  public void skipsOverlyLongStringConstants() {
+    ClassFileConstants.ConstantSet constants = new ClassFileConstants.ConstantSet();
+    constants.ints.add(7);
+    constants.strings.add("short");
+
+    char[] characters = new char[GenInputsAbstract.string_maxlen + 1];
+    Arrays.fill(characters, 'x');
+    constants.strings.add(new String(characters));
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    PrintStream originalOut = System.out;
+    Set<NonreceiverTerm> terms;
+    try {
+      System.setOut(new PrintStream(output));
+      terms = ClassFileConstants.constantSetToNonreceiverTerms(constants);
+    } finally {
+      System.setOut(originalOut);
+    }
+
+    assertEquals(2, terms.size());
+    assertTrue(terms.contains(new NonreceiverTerm(JavaTypes.INT_TYPE, 7)));
+    assertTrue(terms.contains(new NonreceiverTerm(JavaTypes.STRING_TYPE, "short")));
+
+    String warning = new String(output.toByteArray(), StandardCharsets.UTF_8);
+    assertTrue(warning.contains("Ignoring String constant value"));
+    assertTrue(warning.contains("length = " + characters.length));
+  }
+}


### PR DESCRIPTION
## Summary

- skip class-file string constants that exceed Randoop's configured maximum length
- warn with the rejected string's formatted length and continue converting other constants
- add a regression test that preserves normal strings and non-string constants while excluding the oversized value

## Testing

- `gradlew.bat :test --tests randoop.util.ClassFileConstantsTest --no-daemon --console=plain`
- `gradlew.bat spotlessCheck --no-daemon --console=plain`
- Full system-test execution covered 49 cases; its only initial failure was caused by the `JAVA_TOOL_OPTIONS` diagnostic violating `runNoOutputTest`, and that test passed on a clean targeted rerun.

Full Windows `gradlew.bat test` also reaches an unrelated existing failure in `ReplacementFileTest.packageReplacementTest` when handling a `file:/C:/...` URL. Full `gradlew.bat build` additionally reaches an existing Gradle implicit-dependency validation failure in `pmdMain`; the issue-specific test and formatting checks pass.

Fixes #148